### PR TITLE
fix(monitoring): repair the permanently-down TLS certificate monitor

### DIFF
--- a/scripts/uptime-kuma-bootstrap.py
+++ b/scripts/uptime-kuma-bootstrap.py
@@ -324,6 +324,15 @@ class UptimeKumaBootstrap:
             raise Exception(r.get("msg", "Failed to add monitor"))
         return r
 
+    def edit_monitor(self, monitor_data):
+        """Edit an existing monitor. Requires the full object, including its id.
+        Server signature: editMonitor(monitor, callback)
+        """
+        r = self._call("editMonitor", monitor_data)
+        if not r.get("ok"):
+            raise Exception(r.get("msg", "Failed to edit monitor"))
+        return r
+
     def ensure_group_monitor(self, group_name, notification_id):
         """Ensure a group monitor exists. Returns its ID."""
         if group_name in self.monitors:
@@ -432,15 +441,41 @@ class UptimeKumaBootstrap:
         return r.get("monitorID")
 
     def ensure_tls_monitor(self, host_name, notification_id, parent_id=None):
-        """Ensure the wildcard certificate is checked daily via a public HTTPS route."""
+        """Ensure the wildcard certificate is checked daily via a public HTTPS route.
+
+        The URL has to be a route that is NOT behind the lan@docker allowlist.
+        Kuma resolves the public hostname to the WAN address, so the request comes
+        back through the router with a source IP outside ALLOW_IP_RANGES; on a
+        LAN-restricted route Traefik answers 403 and the monitor can never be up.
+        auth is deliberately public (external SSO needs it) and serves the same
+        wildcard certificate, so it is the one host that works here.
+        """
         display_name = "TLS certificate"
-        if display_name in self.monitors:
-            return self.monitors[display_name].get("id")
+        # Must be set: an HTTP monitor left with timeout 0 aborts its own request via
+        # AbortSignal and is permanently down. Docker-type monitors ignore the field,
+        # which is why only this monitor ever needed it.
+        desired = {
+            "url": f"https://auth.{host_name}",
+            "timeout": 48,
+        }
+
+        existing = self.monitors.get(display_name)
+        if existing:
+            drifted = {k: v for k, v in desired.items() if existing.get(k) != v}
+            if not drifted:
+                return existing.get("id")
+            # Converge instead of skipping, so existing installs get repaired: earlier
+            # versions pointed this monitor at LAN-restricted ntfy and never set a
+            # timeout, either of which alone keeps it down.
+            updated = dict(existing)
+            updated.update(desired)
+            self.edit_monitor(updated)
+            log(f"Updated monitor '{display_name}': {', '.join(f'{k}={v}' for k, v in drifted.items())}")
+            return existing.get("id")
 
         monitor_data = {
             "type": "http",
             "name": display_name,
-            "url": f"https://ntfy.{host_name}",
             "interval": 86400,
             "retryInterval": 3600,
             "maxretries": 1,
@@ -448,6 +483,7 @@ class UptimeKumaBootstrap:
             "expiryNotification": True,
             "notificationIDList": {str(notification_id): True} if notification_id else {},
             "conditions": [],
+            **desired,
         }
         if parent_id is not None:
             monitor_data["parent"] = parent_id

--- a/scripts/uptime-kuma-bootstrap.sh
+++ b/scripts/uptime-kuma-bootstrap.sh
@@ -45,6 +45,12 @@ main() {
     # Pull image if needed (will be cached after first run)
     docker image inspect "$PYTHON_IMAGE" >/dev/null 2>&1 || docker pull "$PYTHON_IMAGE"
 
+    # Passed explicitly: the script's fallback shells out to `docker inspect`, which
+    # cannot work inside this container (no docker CLI, no socket mounted), so
+    # without this the TLS certificate monitor is silently skipped.
+    HOST_NAME="${HOST_NAME:-$(get_env_value HOST_NAME)}"
+    [ -n "$HOST_NAME" ] || log "WARNING: HOST_NAME not resolved; TLS certificate monitor will be skipped"
+
     # Run bootstrap Python script inside a temporary container on the frontend
     # network so it can reach pi-uptime-kuma:3001 and pi-ntfy by container name.
     docker run --rm \
@@ -56,6 +62,7 @@ main() {
         -v "$PROJECT_DIR/config/ntfy/ntfy.env:/project/config/ntfy/ntfy.env:ro" \
         -e PROJECT_DIR=/project \
         -e UPTIME_KUMA_URL=http://pi-uptime-kuma:3001 \
+        -e HOST_NAME="$HOST_NAME" \
         "$PYTHON_IMAGE" \
         sh -c 'pip install --quiet --disable-pip-version-check "python-socketio[client]" && python /bootstrap.py'
 }


### PR DESCRIPTION
The `TLS certificate` monitor has been down since it was introduced, taking the `pi-pcloud` group monitor with it and logging a `WARN` every 60 seconds:

```
[MONITOR] WARN: Monitor #65 'pi-pcloud': Failing: Child monitors down: TLS certificate
[MONITOR] WARN: Monitor #99 'TLS certificate': Failing: timeout by AbortSignal (69120000s)
```

Three independent defects, each sufficient on its own to keep it down:

| # | Defect | Effect |
|---|---|---|
| 1 | `timeout` never sent on create, so the row stored `timeout=0` | Kuma aborts its own request (`timeout by AbortSignal`). The visible failure. Only HTTP monitors read the field — the 32 docker-type monitors ignore it, so nothing else was affected. |
| 2 | URL pointed at `ntfy`, which sits behind the `lan@docker` allowlist | Kuma resolves the public hostname to the WAN address, so the request comes back through the router with a source IP outside `ALLOW_IP_RANGES`; Traefik answers **403**, never the accepted 200-299. |
| 3 | The wrapper never passed `HOST_NAME`, and the script's fallback shells out to `docker inspect` from a container with no docker CLI and no socket mounted | On a fresh install `host_name` resolves empty and the monitor is **silently skipped entirely**. |

For (2), verified by hand from inside the Kuma container:

```
ntfy.<domain> -> status=403   (lan@docker allowlist)
auth.<domain> -> status=200
```

`auth` is the only route deliberately left off the allowlist — external SSO needs it — and it serves the very same wildcard certificate, so it is the one host that can satisfy this check over the public path the monitor exercises.

`ensure_tls_monitor` now **converges** rather than returning early when a monitor of that name already exists, so existing installs are repaired by re-running the bootstrap instead of needing a manual edit in the UI. This matches the "only write when config actually changed" guidance in AGENTS.md.

**Verified on the Pi after applying:**
- monitor reports `200 - OK` in 73 ms
- group monitor back to `All children up and running`
- certificate info captured again — Let's Encrypt, `CN=pi.ajir.dev`, SAN `*.pi.ajir.dev`, **41 days** to expiry — so `expiryNotification` alerting genuinely works now rather than just being enabled on a dead monitor
