### PR TITLE
fix(comet): probe health with python, the image no longer ships wget

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1194,8 +1194,9 @@ services:
       - "traefik.http.services.comet.loadbalancer.server.port=8000"
     healthcheck:
       <<: *healthcheck-default
-      # Alpine (busybox) base — wget is available; curl is not.
-      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:8000/health"]
+      # The image ships neither wget nor curl (it moved off its Alpine base and
+      # now carries only the application venv), so probe with that interpreter.
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health', timeout=5)"]
       # First boot blocks ~2-3 min downloading anime mappings before the API serves.
       start_period: 180s
     deploy: *cpu-request-small


### PR DESCRIPTION
## Le problème

Le bump de l'image comet (#178, tag `latest`) l'a fait changer de base : elle ne contient plus ni `wget` ni `curl`, seulement le venv applicatif. Le healthcheck appelait toujours `wget` :

```
OCI runtime exec failed: exec: "wget": executable file not found in $PATH
```

Chaque sonde échouait, donc le conteneur ne pouvait que basculer `unhealthy` à l'expiration de son `start_period` de 180 s. Le service, lui, allait très bien : `/health` répond `{"status":"ok"}`.

## Conséquences

- C'est l'échec du job **Smoke Test Stack Startup** sur `main` (`container pi-comet is unhealthy`) — la CI est rouge pour ça, pas pour autre chose.
- Sur le Pi : dockhand pousse une alerte `container_unhealthy` à chaque redémarrage, et depuis le passage à l'alerting par groupe, comet met tout le groupe **Media & Downloads** en échec permanent.

## Le correctif

Sonde via l'interpréteur que l'image embarque :

```yaml
test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health', timeout=5)"]
```

`urlopen` lève sur tout code non-2xx, donc le code de sortie suffit.

## Vérification

Appliqué sur la stack live : conteneur recréé, sonde à `exit 0`, `healthy`. Stack complète à 34 conteneurs / 33 healthy / 0 en échec (le 34ᵉ est `dagger-engine`, sans healthcheck et hors stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)