### PR TITLE
feat(ai): local Gemma 4 E2B inference with llama.cpp, wired to Open WebUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ If you're deciding between approaches, here's the short version:
 | **Network & Security** | Traefik (reverse proxy), Tailscale/Headscale (VPN), Authelia (SSO), LLDAP (user directory) |
 | **DNS & Filtering** | Pi-hole (ad-blocking), Unbound (recursive DNS) |
 | **Download** | qBittorrent (torrent client), Prowlarr (indexer manager), Kapowarr (comics manager), FlareSolverr (Cloudflare solver), Gluetun (VPN kill-switch gateway) |
+| **AI** | Open WebUI (chat interface), llama.cpp (local Gemma 4 E2B inference, CPU-only) |
 | **Monitoring & Backup** | Beszel (monitoring), Backrest (restic backups), Dockhand (container management) |
 | **Infrastructure** | PostgreSQL, Redis, ddns-updater |
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you're deciding between approaches, here's the short version:
 | **Network & Security** | Traefik (reverse proxy), Tailscale/Headscale (VPN), Authelia (SSO), LLDAP (user directory) |
 | **DNS & Filtering** | Pi-hole (ad-blocking), Unbound (recursive DNS) |
 | **Download** | qBittorrent (torrent client), Prowlarr (indexer manager), Kapowarr (comics manager), FlareSolverr (Cloudflare solver), Gluetun (VPN kill-switch gateway) |
-| **AI** | Open WebUI (chat interface), llama.cpp (local Gemma 4 E2B inference, CPU-only) |
+| **AI** | Open WebUI (chat interface), llama.cpp (local Gemma 4 E2B inference, CPU-only), Piper (French text-to-speech) |
 | **Monitoring & Backup** | Beszel (monitoring), Backrest (restic backups), Dockhand (container management) |
 | **Infrastructure** | PostgreSQL, Redis, ddns-updater |
 

--- a/compose.test.yaml
+++ b/compose.test.yaml
@@ -52,6 +52,11 @@ services:
     # seeds into the llama_models volume, which CI does not run.
     profiles: [ci-excluded]
 
+  piper:
+    # Builds an image that downloads ~180MB of voice models; nothing else in the
+    # stack depends on it being up.
+    profiles: [ci-excluded]
+
   # --- open-webui: run without the excluded inference backend ---
   open-webui:
     # depends_on must be reset, not merged: compose would otherwise pull

--- a/compose.test.yaml
+++ b/compose.test.yaml
@@ -47,6 +47,24 @@ services:
     # not resolve on GitHub Actions runners.
     profiles: [ci-excluded]
 
+  llama-cpp:
+    # Needs the 4.4GB of Gemma 4 weights that scripts/llama-cpp-pre-start.sh
+    # seeds into the llama_models volume, which CI does not run.
+    profiles: [ci-excluded]
+
+  # --- open-webui: run without the excluded inference backend ---
+  open-webui:
+    # depends_on must be reset, not merged: compose would otherwise pull
+    # llama-cpp back in despite its profile.
+    depends_on: !override
+      postgres:
+        condition: service_healthy
+    # Merged into the list from compose.yaml, so nothing else is lost. Without
+    # it open-webui blocks on an unreachable http://llama-cpp:8080/v1 whenever
+    # it builds a model list.
+    environment:
+      - ENABLE_OPENAI_API=false
+
   # --- nextcloud: replace host bind mounts with named volumes for CI ---
   # In CI the host directories (./data/nextcloud-config, ./data/nextcloud) do not
   # pre-exist, so Docker creates them as root:root.  Nextcloud runs as www-data

--- a/compose.yaml
+++ b/compose.yaml
@@ -1700,6 +1700,39 @@ services:
     mem_limit: 6g
     oom_score_adj: *oom-score-deprioritize
 
+  # Text-to-speech for open-webui's read-aloud button, with real French voices.
+  #
+  # Built here because upstream (OHF-Voice/piper1-gpl) publishes no image, and
+  # its own HTTP server speaks its own protocol rather than the OpenAI shape
+  # open-webui calls - see config/piper/openai_api.py for that translation.
+  # Piper is tiny next to the LLM: ~215MB resident, and it synthesises about
+  # five seconds of speech per second of CPU on this Pi.
+  piper:
+    <<: *service-defaults
+    build:
+      context: ./config/piper
+      dockerfile: Dockerfile
+    image: pi-piper:local
+    container_name: pi-piper
+    networks:
+      - ai
+    expose:
+      - 8000
+    environment:
+      # Used when a request asks for a voice that does not exist here - which
+      # includes every OpenAI voice name open-webui defaults to (alloy, echo).
+      - PIPER_DEFAULT_VOICE=fr_FR-siwis-medium
+    healthcheck:
+      <<: *healthcheck-relaxed
+      # python:3.12-slim ships no curl or wget, but python is the point of it.
+      test: ["CMD", "python3", "-c", "import urllib.request as r; r.urlopen('http://localhost:8000/health').read()"]
+      start_period: 30s
+    deploy: *cpu-request-small
+    # Same three cores as llama-cpp, leaving core 0 to traefik and DNS.
+    cpuset: "1-3"
+    mem_limit: 512m
+    oom_score_adj: *oom-score-deprioritize
+
   open-webui:
     <<: *service-defaults
     image: ghcr.io/open-webui/open-webui:v0.11.0

--- a/compose.yaml
+++ b/compose.yaml
@@ -1668,10 +1668,20 @@ services:
       # default, but --cache-reuse cannot be added on top - llama-server
       # disables it whenever a multimodal projector is loaded.
       #
-      # Gemma 4 thinks before answering. Unbounded that is minutes of a chat
-      # window sitting empty at 10 tok/s, so cap it: 0 disables thinking
-      # entirely, -1 restores the model default.
-      - LLAMA_ARG_THINK_BUDGET=512
+      # Thinking off. Gemma 4 reasons before answering, which on a 10 tok/s CPU
+      # meant ~500 tokens - a minute of an empty chat window - before the first
+      # word of the answer to "how are you"; with it off the same question
+      # answers in 25 tokens. This is the switch the chat template actually
+      # reads. Note --reasoning-budget 0 is NOT equivalent: it closes the
+      # thinking channel without telling the model, which then writes its
+      # reasoning into the visible answer instead. Delete this line to restore
+      # thinking, or send "chat_template_kwargs" per request to override it.
+      - 'LLAMA_ARG_CHAT_TEMPLATE_KWARGS={"enable_thinking":false}'
+      # One slot, so concurrent requests queue instead of splitting the three
+      # threads between them. llama-server otherwise defaults to several slots
+      # and runs them at once: two requests in parallel each generated at
+      # ~5 tok/s here rather than one at ~10, so everything felt twice as slow.
+      - LLAMA_ARG_N_PARALLEL=1
       # llama.cpp ships its own chat UI; open-webui is the one that is routed,
       # so keep the surface down to the API.
       - LLAMA_ARG_UI=false

--- a/compose.yaml
+++ b/compose.yaml
@@ -1622,6 +1622,74 @@ services:
     oom_score_adj: *oom-score-critical
 
   # AI
+  # Inference backend for open-webui, serving Gemma 4 E2B on the Pi's CPU.
+  #
+  # llama.cpp's own server rather than Ollama: Ollama wraps this exact engine,
+  # and what it adds - a model registry, per-request runner processes, model
+  # swapping - is dead weight on a box with room for one resident model. Going
+  # direct is measurably faster on ARM CPU inference (llama-server repacks Q4_0
+  # weights into the Cortex-A76's i8mm/dotprod kernels), starts one process
+  # instead of two, and speaks the OpenAI API open-webui already talks.
+  llama-cpp:
+    <<: *service-defaults
+    image: ghcr.io/ggml-org/llama.cpp:server-b10454
+    container_name: pi-llama-cpp
+    networks:
+      - ai
+    expose:
+      - 8080
+    environment:
+      # The ai network is internal, so the server can never fetch weights
+      # itself - scripts/llama-cpp-pre-start.sh seeds the volume beforehand and
+      # LLAMA_ARG_OFFLINE stops llama-server from even trying.
+      - LLAMA_ARG_MODEL=/models/gemma-4-E2B-it-qat-Q4_0.gguf
+      - LLAMA_ARG_MMPROJ=/models/mmproj-gemma-4-E2B-it.gguf
+      - LLAMA_ARG_OFFLINE=1
+      # Speculative decoding off Gemma 4's multi-token-prediction head. Token
+      # generation on CPU is bandwidth bound, so verifying several drafted
+      # tokens in one pass over the weights is close to free: measured 5.3 ->
+      # 10.6 tok/s on this Pi. Output is unchanged, rejected drafts are dropped.
+      - LLAMA_ARG_SPEC_DRAFT_MODEL=/models/mtp-gemma-4-E2B-it-Q4_0.gguf
+      - LLAMA_ARG_SPEC_TYPE=draft-mtp
+      # Name open-webui shows in its model picker.
+      - LLAMA_ARG_ALIAS=gemma-4-e2b-it
+      - LLAMA_ARG_PORT=8080
+      # Three threads on cores 1-3 (see cpuset): generation is bandwidth bound,
+      # so the fourth thread measured no faster, and leaving core 0 alone keeps
+      # traefik, pihole and unbound responsive while a chat is running.
+      - LLAMA_ARG_THREADS=3
+      - LLAMA_ARG_FLASH_ATTN=on
+      # Gemma 4 E2B goes to 128k, which no Pi has the RAM or the patience for.
+      # 16k covers a long chat. Left at f16: Gemma's sliding-window attention
+      # keeps the cache small, and quantising it cost ~10% generation speed
+      # here for no memory worth having.
+      - LLAMA_ARG_CTX_SIZE=16384
+      # Note: prompt caching (the KV prefix a chat re-sends every turn) is on by
+      # default, but --cache-reuse cannot be added on top - llama-server
+      # disables it whenever a multimodal projector is loaded.
+      #
+      # Gemma 4 thinks before answering. Unbounded that is minutes of a chat
+      # window sitting empty at 10 tok/s, so cap it: 0 disables thinking
+      # entirely, -1 restores the model default.
+      - LLAMA_ARG_THINK_BUDGET=512
+      # llama.cpp ships its own chat UI; open-webui is the one that is routed,
+      # so keep the surface down to the API.
+      - LLAMA_ARG_UI=false
+    volumes:
+      - llama_models:/models
+    healthcheck:
+      <<: *healthcheck-relaxed
+      # /health is 503 while the weights load, 200 once a slot is free.
+      test: ["CMD", "curl", "-fsS", "http://localhost:8080/health"]
+      start_period: 120s
+      start_interval: 5s
+    deploy: *cpu-request-xlarge
+    cpuset: "1-3"
+    # Weights are mmap'd, and the cgroup counts those pages: 3.4G of model plus
+    # ~1G of vision projector, KV cache and compute buffers.
+    mem_limit: 6g
+    oom_score_adj: *oom-score-deprioritize
+
   open-webui:
     <<: *service-defaults
     image: ghcr.io/open-webui/open-webui:v0.11.0
@@ -1645,12 +1713,23 @@ services:
       - OAUTH_SCOPES=openid profile email
       - OAUTH_USERNAME_CLAIM=preferred_username
       - DATABASE_URL=postgresql://open-webui:${PASSWORD}@postgres/open-webui
+      # Local inference through llama-cpp's OpenAI-compatible endpoint. The key
+      # is required by the client but ignored by llama-server, which runs
+      # unauthenticated on the internal ai network.
+      - ENABLE_OPENAI_API=true
+      - OPENAI_API_BASE_URL=http://llama-cpp:8080/v1
+      - OPENAI_API_KEY=llama-cpp
+      # No Ollama in the stack; left on, open-webui probes localhost:11434 on
+      # every start and on the model list of every page load.
+      - ENABLE_OLLAMA_API=false
     volumes:
       - open_webui_data:/app/backend/data
       - ${DATA_LOCATION:-./data}/authelia-config/secrets/oidc_open-webui_secret.txt:/run/secrets/oidc_open-webui_secret:ro
     depends_on:
       postgres:
         condition: service_healthy
+      llama-cpp:
+        condition: service_started
     healthcheck:
       <<: *healthcheck-relaxed
       test: ["CMD", "curl", "-fsS", "http://localhost:8080"]
@@ -1725,6 +1804,10 @@ services:
     oom_score_adj: *oom-score-critical
 
 volumes:
+  # Seeded by scripts/llama-cpp-pre-start.sh before compose runs. A volume, not
+  # a DATA_LOCATION bind mount, so the weights live on the NVMe root rather
+  # than the rotational USB drive - they are mmap'd on every model load.
+  llama_models:
   open_webui_data:
   ddns_data:
   stremio_data:

--- a/config/llama-cpp/fetch-models.sh
+++ b/config/llama-cpp/fetch-models.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Downloads the GGUF weights llama-cpp serves, into the mounted /models volume.
+#
+# Runs INSIDE the llama.cpp image (it ships bash + curl), started by
+# scripts/llama-cpp-pre-start.sh. It lives here rather than being inlined in
+# that script so the quoting stays readable and the download can be re-run by
+# hand:
+#   docker run --rm -v llama_models:/models \
+#     -v ./config/llama-cpp/fetch-models.sh:/fetch-models.sh:ro \
+#     --entrypoint bash ghcr.io/ggml-org/llama.cpp:server-bXXXXX /fetch-models.sh
+#
+# Idempotent: a file whose size already matches the remote one is left alone,
+# a partial download is resumed rather than restarted.
+set -euo pipefail
+
+MODELS_DIR="${MODELS_DIR:-/models}"
+
+# "<destination file>|<url>". The main weights are Google's own QAT build:
+# quantisation-aware training recovers most of the quality that plain
+# post-training Q4_0 loses, at identical size and speed. Q4_0 specifically (not
+# Q4_K_M) because llama.cpp repacks it into the ARM i8mm/dotprod kernels the
+# Pi 5's Cortex-A76 has, which is worth more than the quant format difference.
+#
+# The third file is the multi-token-prediction head, used as the draft model for
+# speculative decoding. It is 57MB and roughly doubled generation speed on the
+# Pi 5 in testing (5.3 -> 10.6 tok/s), because the expensive part of CPU
+# inference is streaming the weights through memory once per token, and one
+# pass can verify several drafted tokens. Speculative decoding does not change
+# what the model outputs - drafts the main model rejects are discarded.
+DOWNLOADS="
+gemma-4-E2B-it-qat-Q4_0.gguf|https://huggingface.co/google/gemma-4-E2B-it-qat-q4_0-gguf/resolve/main/gemma-4-E2B_q4_0-it.gguf
+mmproj-gemma-4-E2B-it.gguf|https://huggingface.co/google/gemma-4-E2B-it-qat-q4_0-gguf/resolve/main/gemma-4-E2B-it-mmproj.gguf
+mtp-gemma-4-E2B-it-Q4_0.gguf|https://huggingface.co/ggml-org/gemma-4-E2B-it-GGUF/resolve/main/mtp-gemma-4-E2B-it-Q4_0.gguf
+"
+
+log() {
+    echo "[fetch-models] $*" >&2
+}
+
+remote_size() {
+    # HuggingFace serves LFS objects through a redirect; the size that matters
+    # is the content-length of the final hop, so keep the last one seen.
+    curl -fsIL --retry 3 --retry-delay 2 "$1" 2>/dev/null |
+        tr -d '\r' |
+        awk -F': ' 'tolower($1) == "content-length" { size = $2 } END { print size }'
+}
+
+fetch() {
+    local dest="$MODELS_DIR/$1"
+    local url="$2"
+    local expected actual
+
+    expected="$(remote_size "$url" || true)"
+
+    if [ -f "$dest" ]; then
+        actual="$(stat -c '%s' "$dest")"
+        if [ -z "$expected" ]; then
+            log "$1 present, remote size unknown (offline?) - keeping it"
+            return 0
+        fi
+        if [ "$actual" = "$expected" ]; then
+            log "$1 up to date ($actual bytes)"
+            return 0
+        fi
+        log "$1 size mismatch (local $actual, remote $expected) - refetching"
+        rm -f "$dest"
+    elif [ -z "$expected" ]; then
+        log "ERROR: $1 is missing and $url is unreachable"
+        return 1
+    fi
+
+    log "Downloading $1 ($expected bytes)"
+    # No progress meter: this runs from systemd, where it would be thousands of
+    # journald lines. The two log lines around it are the progress report.
+    curl -fL --retry 3 --retry-delay 2 --no-progress-meter --continue-at - -o "$dest.part" "$url"
+
+    actual="$(stat -c '%s' "$dest.part")"
+    if [ "$actual" != "$expected" ]; then
+        log "ERROR: $1 downloaded $actual bytes, expected $expected"
+        rm -f "$dest.part"
+        return 1
+    fi
+
+    mv "$dest.part" "$dest"
+    log "$1 ready"
+}
+
+main() {
+    mkdir -p "$MODELS_DIR"
+
+    while IFS='|' read -r name url; do
+        [ -n "$name" ] || continue
+        fetch "$name" "$url"
+    done <<< "$DOWNLOADS"
+}
+
+main "$@"

--- a/config/piper/Dockerfile
+++ b/config/piper/Dockerfile
@@ -1,0 +1,37 @@
+# Piper TTS (OHF-Voice/piper1-gpl) behind an OpenAI-compatible facade.
+#
+# Upstream publishes no image, and its own HTTP server speaks its own protocol
+# (POST / + GET /voices) rather than the /v1/audio/speech shape Open WebUI's
+# "OpenAI" TTS engine calls. openai_api.py is that translation layer; it uses
+# Piper's Python API directly, so this stays a single process.
+FROM python:3.12-slim
+
+# piper-tts publishes a manylinux aarch64 wheel, so nothing is compiled here and
+# the image builds in seconds on the Pi. Pinned, like every other image here.
+ARG PIPER_VERSION=1.7.0
+
+# Baked into the image rather than downloaded at start: the ai network is
+# internal, and three voices are only ~180MB. fr_FR-siwis-medium is the usual
+# French reference voice (female), tom is male, upmc is a second female with a
+# different timbre. en_US-lessac-medium is there so English text in a reply does
+# not get read with a French phonemiser.
+ARG VOICES="fr_FR-siwis-medium fr_FR-tom-medium fr_FR-upmc-medium en_US-lessac-medium"
+
+ENV PIPER_VOICE_DIR=/voices \
+    PYTHONUNBUFFERED=1
+
+RUN pip install --no-cache-dir \
+        "piper-tts==${PIPER_VERSION}" \
+        "fastapi>=0.115,<1" \
+        "uvicorn>=0.34,<1"
+
+RUN mkdir -p "$PIPER_VOICE_DIR" \
+    && for voice in $VOICES; do \
+        python3 -m piper.download_voices "$voice" --data-dir "$PIPER_VOICE_DIR"; \
+    done
+
+COPY openai_api.py /app/openai_api.py
+WORKDIR /app
+
+EXPOSE 8000
+CMD ["uvicorn", "openai_api:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "1"]

--- a/config/piper/openai_api.py
+++ b/config/piper/openai_api.py
@@ -1,0 +1,122 @@
+"""OpenAI-compatible TTS facade over Piper (OHF-Voice/piper1-gpl).
+
+Open WebUI's "OpenAI" TTS engine calls three endpoints on its configured base
+URL, so those are exactly what this serves:
+
+    POST /v1/audio/speech   {"input": ..., "voice": ..., "speed": ...} -> WAV
+    GET  /v1/audio/voices   {"voices": [{"id", "name"}, ...]}
+    GET  /v1/audio/models   {"models": [{"id"}, ...]}
+
+Piper reads a .onnx per voice off disk; loading one costs about a second, so
+they are cached after first use. Synthesis is CPU-bound and releases no GIL
+worth speaking of, hence the single worker and the lock: on this Pi the point is
+to never take more than one core away from llama-cpp, which is sharing the same
+three.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import os
+import threading
+import wave
+from pathlib import Path
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import JSONResponse, Response
+from piper import PiperVoice, SynthesisConfig
+from pydantic import BaseModel
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("piper-openai")
+
+VOICE_DIR = Path(os.environ.get("PIPER_VOICE_DIR", "/voices"))
+DEFAULT_VOICE = os.environ.get("PIPER_DEFAULT_VOICE", "fr_FR-siwis-medium")
+
+app = FastAPI(title="Piper OpenAI-compatible TTS")
+
+_voices: dict[str, PiperVoice] = {}
+_load_lock = threading.Lock()
+_synth_lock = threading.Lock()
+
+
+def available_voices() -> list[str]:
+    """Voice ids, taken from the .onnx files baked into the image."""
+    return sorted(p.stem for p in VOICE_DIR.rglob("*.onnx"))
+
+
+def voice_path(name: str) -> Path | None:
+    for path in VOICE_DIR.rglob("*.onnx"):
+        if path.stem == name:
+            return path
+    return None
+
+
+def get_voice(name: str) -> PiperVoice:
+    """Load a voice once and keep it resident."""
+    with _load_lock:
+        if name not in _voices:
+            path = voice_path(name)
+            if path is None:
+                raise HTTPException(status_code=400, detail=f"unknown voice: {name}")
+            log.info("loading voice %s", name)
+            _voices[name] = PiperVoice.load(str(path))
+        return _voices[name]
+
+
+class SpeechRequest(BaseModel):
+    input: str = ""
+    # Accepted and ignored: the model is the voice here. Open WebUI always sends
+    # whatever is in its "TTS model" box (tts-1 by default).
+    model: str | None = None
+    voice: str | None = None
+    response_format: str | None = None
+    # OpenAI's 0.25-4.0 multiplier. Piper scales the other way round: its
+    # length_scale stretches the audio, so speed 2.0 is length_scale 0.5.
+    speed: float | None = None
+
+
+@app.get("/v1/audio/voices")
+def list_voices() -> JSONResponse:
+    voices = [{"id": name, "name": name} for name in available_voices()]
+    return JSONResponse({"voices": voices})
+
+
+@app.get("/v1/audio/models")
+def list_models() -> JSONResponse:
+    # Open WebUI shows these in its "TTS model" dropdown. Piper has no separate
+    # model axis, so report the voices again rather than an empty list.
+    return JSONResponse({"models": [{"id": name} for name in available_voices()]})
+
+
+@app.get("/health")
+def health() -> JSONResponse:
+    return JSONResponse({"status": "ok", "voices": available_voices()})
+
+
+@app.post("/v1/audio/speech")
+def speech(req: SpeechRequest) -> Response:
+    text = (req.input or "").strip()
+    if not text:
+        raise HTTPException(status_code=400, detail="input is empty")
+
+    name = req.voice or DEFAULT_VOICE
+    if voice_path(name) is None:
+        # Open WebUI ships OpenAI's own voice names (alloy, echo, ...) as its
+        # default; fall back rather than fail the first play button.
+        log.info("voice %r unavailable, falling back to %s", name, DEFAULT_VOICE)
+        name = DEFAULT_VOICE
+
+    voice = get_voice(name)
+
+    config = SynthesisConfig()
+    if req.speed and req.speed > 0:
+        config.length_scale = 1.0 / req.speed
+
+    buffer = io.BytesIO()
+    with _synth_lock:
+        with wave.open(buffer, "wb") as wav_file:
+            voice.synthesize_wav(text, wav_file, syn_config=config)
+
+    return Response(content=buffer.getvalue(), media_type="audio/wav")

--- a/config/systemd/system/pi-pcloud.service
+++ b/config/systemd/system/pi-pcloud.service
@@ -29,6 +29,7 @@ ExecStartPost=-/bin/sh __PROJECT_PATH__/scripts/prowlarr-bootstrap.sh
 ExecStartPost=-/bin/sh __PROJECT_PATH__/scripts/kapowarr-bootstrap.sh
 ExecStartPost=-/bin/sh __PROJECT_PATH__/scripts/uptime-kuma-bootstrap.sh
 ExecStartPost=-/bin/sh __PROJECT_PATH__/scripts/kavita-oidc-bootstrap.sh
+ExecStartPost=-/bin/sh __PROJECT_PATH__/scripts/open-webui-bootstrap.sh
 ExecStartPost=-/bin/sh __PROJECT_PATH__/scripts/homepage-widgets-bootstrap.sh
 ExecStop=/usr/bin/docker compose down --remove-orphans
 RemainAfterExit=true

--- a/config/systemd/system/pi-pcloud.service
+++ b/config/systemd/system/pi-pcloud.service
@@ -17,6 +17,7 @@ ExecStartPre=/bin/sh __PROJECT_PATH__/scripts/ntfy-pre-start.sh
 ExecStartPre=/bin/sh __PROJECT_PATH__/scripts/qbittorrent-pre-start.sh
 ExecStartPre=/bin/sh __PROJECT_PATH__/scripts/prowlarr-pre-start.sh
 ExecStartPre=/bin/sh __PROJECT_PATH__/scripts/kapowarr-pre-start.sh
+ExecStartPre=/bin/sh __PROJECT_PATH__/scripts/llama-cpp-pre-start.sh
 ExecStart=/usr/bin/docker compose up -d
 ExecStartPost=-/bin/bash __PROJECT_PATH__/scripts/headscale-init.sh
 ExecStartPost=-/bin/sh __PROJECT_PATH__/scripts/beszel-agent-bootstrap.sh

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -250,7 +250,24 @@ stack: llama.cpp is the engine Ollama wraps, and running it directly is faster
 on ARM CPU and one process instead of two.
 
 Measured on a Raspberry Pi 5 (16GB, 3 threads pinned to cores 1-3):
-~10 tok/s generation, ~40 tok/s prompt processing, ~3.7GB resident.
+~10 tok/s generation, ~40 tok/s prompt processing, ~3.7GB resident. A short
+question answers in about 3 seconds end to end.
+
+**Latency comes from prompt size, not the model.** Three defaults exist purely
+because ~30 tok/s of prompt processing punishes anything verbose:
+
+- *Thinking is off* (`LLAMA_ARG_CHAT_TEMPLATE_KWARGS`). Gemma 4 otherwise spends
+  ~500 tokens reasoning before the first visible word - over a minute of empty
+  chat window for "how are you".
+- *One server slot* (`LLAMA_ARG_N_PARALLEL=1`). llama-server defaults to several
+  and runs them concurrently, so two requests each generated at ~5 tok/s instead
+  of one at ~10. Queueing is faster than sharing three threads.
+- *Open WebUI's built-in tools are off for this model*, along with title, tag,
+  follow-up and search-query generation. Built-in tools (time, memory, chats,
+  notes, knowledge, channels) inject ~5000 tokens of schemas into every message
+  sent from the browser - roughly three minutes of prompt processing before the
+  model starts. The other four are invisible extra LLM calls per message.
+  All are re-enablable in Admin Settings and in the model's own Capabilities.
 
 **Where the weights live.** `scripts/llama-cpp-pre-start.sh` downloads them into
 the `llama_models` Docker volume (on the NVMe root, not `DATA_LOCATION`) before
@@ -269,8 +286,10 @@ connections the model simply never shows up in the picker.
 `scripts/open-webui-bootstrap.sh` (an `ExecStartPost` hook) appends
 `http://llama-cpp:8080/v1` to the stored connection list when it is missing,
 leaves any other connection you configured in the UI alone, and restarts
-open-webui only when it changed something. Run it by hand after a database
-restore:
+open-webui only when it changed something. It also seeds the low-latency
+defaults above - once, guarded by a `pi-pcloud.local_ai_defaults` marker row, so
+anything you change afterwards in Admin Settings stays changed. Run it by hand
+after a database restore:
 
 ```bash
 sh scripts/open-webui-bootstrap.sh

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -262,6 +262,20 @@ size does not match the remote one. To re-check by hand:
 sh scripts/llama-cpp-pre-start.sh
 ```
 
+**Why the connection is bootstrapped, not just configured.** `OPENAI_API_BASE_URL`
+and friends are Open WebUI *PersistentConfig* variables: they seed the database
+on first start and are ignored afterwards, so on an instance that already has
+connections the model simply never shows up in the picker.
+`scripts/open-webui-bootstrap.sh` (an `ExecStartPost` hook) appends
+`http://llama-cpp:8080/v1` to the stored connection list when it is missing,
+leaves any other connection you configured in the UI alone, and restarts
+open-webui only when it changed something. Run it by hand after a database
+restore:
+
+```bash
+sh scripts/open-webui-bootstrap.sh
+```
+
 **Changing the model.** Edit the `DOWNLOADS` list in
 `config/llama-cpp/fetch-models.sh`, then point `LLAMA_ARG_MODEL` (and
 `LLAMA_ARG_MMPROJ` / `LLAMA_ARG_SPEC_DRAFT_MODEL`, or drop them) at the new

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -241,6 +241,44 @@ To add a service:
 5. Update ALLOW_IP_RANGES if needed
 6. Run `make install` or `make restart`
 
+### Local AI Model (llama.cpp + Open WebUI)
+
+Open WebUI at `https://ai.<YOUR_DOMAIN>` talks to `llama-cpp`, which serves
+**Gemma 4 E2B** (Google's QAT Q4_0 build, text + image + audio in) over an
+OpenAI-compatible API on the internal `ai` network. There is no Ollama in the
+stack: llama.cpp is the engine Ollama wraps, and running it directly is faster
+on ARM CPU and one process instead of two.
+
+Measured on a Raspberry Pi 5 (16GB, 3 threads pinned to cores 1-3):
+~10 tok/s generation, ~40 tok/s prompt processing, ~3.7GB resident.
+
+**Where the weights live.** `scripts/llama-cpp-pre-start.sh` downloads them into
+the `llama_models` Docker volume (on the NVMe root, not `DATA_LOCATION`) before
+the stack starts, because the `ai` network is internal and the container cannot
+reach HuggingFace itself. It is idempotent - it only re-downloads a file whose
+size does not match the remote one. To re-check by hand:
+
+```bash
+sh scripts/llama-cpp-pre-start.sh
+```
+
+**Changing the model.** Edit the `DOWNLOADS` list in
+`config/llama-cpp/fetch-models.sh`, then point `LLAMA_ARG_MODEL` (and
+`LLAMA_ARG_MMPROJ` / `LLAMA_ARG_SPEC_DRAFT_MODEL`, or drop them) at the new
+files in `compose.yaml`. Prefer `Q4_0` quantisations: llama.cpp repacks those
+into the ARM i8mm/dotprod kernels the Pi 5 has. Anything much past ~4B
+parameters will be too slow to chat with on CPU.
+
+**Tuning knobs** (all `environment:` entries on the `llama-cpp` service):
+
+| Variable | Default here | Notes |
+|----------|--------------|-------|
+| `LLAMA_ARG_CTX_SIZE` | `16384` | Context window. The model supports 128k; RAM and prompt-processing time do not. |
+| `LLAMA_ARG_THINK_BUDGET` | `512` | Thinking-token cap. `0` disables reasoning (fastest first token), `-1` lets it run unrestricted. |
+| `LLAMA_ARG_THREADS` | `3` | Matched to `cpuset: "1-3"`, leaving core 0 for Traefik and DNS. A 4th thread measured no faster. |
+| `LLAMA_ARG_SPEC_TYPE` | `draft-mtp` | Speculative decoding via Gemma 4's multi-token-prediction head; roughly doubles generation speed. Remove it and `LLAMA_ARG_SPEC_DRAFT_MODEL` to disable. |
+| `LLAMA_ARG_MMPROJ` | mmproj file | Vision/audio input. Removing it saves ~1GB of RAM and re-enables `--cache-reuse`. |
+
 ### Changing Passwords
 
 **LLDAP admin (the shared `PASSWORD` / SSO master credential) - after a leak:**

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -295,6 +295,28 @@ after a database restore:
 sh scripts/open-webui-bootstrap.sh
 ```
 
+**French text-to-speech.** The read-aloud button goes through `piper`, built
+from `config/piper/` on top of [OHF-Voice/piper1-gpl](https://github.com/OHF-Voice/piper1-gpl).
+Upstream publishes no image and its HTTP server speaks its own protocol, so the
+image adds `config/piper/openai_api.py`, a small OpenAI-compatible facade
+(`/v1/audio/speech`, `/v1/audio/voices`, `/v1/audio/models`) - the shape Open
+WebUI's "OpenAI" TTS engine calls. Voices are baked into the image:
+
+| Voice | |
+|-------|---|
+| `fr_FR-siwis-medium` | French, female - the default |
+| `fr_FR-tom-medium` | French, male |
+| `fr_FR-upmc-medium` | French, female, different timbre |
+| `en_US-lessac-medium` | English, so English text is not read with a French phonemiser |
+
+Roughly five seconds of speech per second of CPU, ~215MB resident. Pick a voice
+per user in **Settings → Audio**; it overrides the default, and a request for a
+voice Piper does not have falls back rather than failing. To add voices, extend
+`VOICES` in `config/piper/Dockerfile` (the catalogue is
+[rhasspy/piper-voices](https://huggingface.co/rhasspy/piper-voices)) and rebuild
+with `docker compose build piper`. To go back to the browser's own voices, set
+the TTS engine to Web API in Admin Settings - nothing re-imposes Piper.
+
 **Changing the model.** Edit the `DOWNLOADS` list in
 `config/llama-cpp/fetch-models.sh`, then point `LLAMA_ARG_MODEL` (and
 `LLAMA_ARG_MMPROJ` / `LLAMA_ARG_SPEC_DRAFT_MODEL`, or drop them) at the new

--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -292,7 +292,7 @@ decides the check interval, the retry budget and the ntfy priority:
 | **Personal Data** | immich, immich-ml, nextcloud, vaultwarden, kavita, backrest | 120s | `ntfy` (prio 3) | each monitor |
 | **Media & Downloads** | qbittorrent, stremio, comet, prowlarr, kapowarr, flaresolverr, route qbittorrent | 300s | `ntfy-low` (prio 2) | the group only |
 | **Tools & Observability** | homepage, beszel, beszel-agent, dockhand | 300s | `ntfy-low` (prio 2) | the group only |
-| **Automation & AI** | n8n, n8n-runners, open-webui | 300s | `ntfy-low` (prio 2) | the group only |
+| **Automation & AI** | n8n, n8n-runners, open-webui, llama-cpp | 300s | `ntfy-low` (prio 2) | the group only |
 
 `ntfy` sits in **Core** because it delivers every other alert. A container that
 is in `compose.yaml` but in no group above is monitored under

--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -292,7 +292,7 @@ decides the check interval, the retry budget and the ntfy priority:
 | **Personal Data** | immich, immich-ml, nextcloud, vaultwarden, kavita, backrest | 120s | `ntfy` (prio 3) | each monitor |
 | **Media & Downloads** | qbittorrent, stremio, comet, prowlarr, kapowarr, flaresolverr, route qbittorrent | 300s | `ntfy-low` (prio 2) | the group only |
 | **Tools & Observability** | homepage, beszel, beszel-agent, dockhand | 300s | `ntfy-low` (prio 2) | the group only |
-| **Automation & AI** | n8n, n8n-runners, open-webui, llama-cpp | 300s | `ntfy-low` (prio 2) | the group only |
+| **Automation & AI** | n8n, n8n-runners, open-webui, llama-cpp, piper | 300s | `ntfy-low` (prio 2) | the group only |
 
 `ntfy` sits in **Core** because it delivers every other alert. A container that
 is in `compose.yaml` but in no group above is monitored under

--- a/scripts/llama-cpp-pre-start.sh
+++ b/scripts/llama-cpp-pre-start.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+# Seeds the llama_models volume before the stack starts.
+#
+# llama-cpp sits on the "ai" network, which is internal: it has no route out, so
+# it cannot pull its own weights the way `llama-server -hf ...` normally would.
+# Fetching them here keeps the inference container air-gapped and keeps the
+# download on the host's NVMe (a Docker volume) rather than the rotational USB
+# drive DATA_LOCATION points at - the weights are mmap'd on every load.
+set -eu
+
+. "$(dirname "$0")/lib.sh"
+
+# Keep in sync with the llama-cpp image tag in compose.yaml.
+LLAMA_IMAGE="${LLAMA_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-b10454}"
+FETCH_SCRIPT="$PROJECT_DIR/config/llama-cpp/fetch-models.sh"
+
+# compose prefixes volume names with the project name (the project directory
+# unless COMPOSE_PROJECT_NAME says otherwise); mirror that so both sides mean
+# the same volume.
+PROJECT_NAME="${COMPOSE_PROJECT_NAME:-$(basename "$PROJECT_DIR")}"
+VOLUME_NAME="${PROJECT_NAME}_llama_models"
+
+# Create the volume the way compose would, labels included, so `docker compose
+# up` adopts it silently instead of warning that it did not create it.
+ensure_volume() {
+    if docker volume inspect "$VOLUME_NAME" >/dev/null 2>&1; then
+        return 0
+    fi
+
+    docker volume create \
+        --label "com.docker.compose.project=$PROJECT_NAME" \
+        --label "com.docker.compose.volume=llama_models" \
+        --label "com.docker.compose.version=$(docker compose version --short)" \
+        "$VOLUME_NAME" >/dev/null
+}
+
+main() {
+    if ! docker image inspect "$LLAMA_IMAGE" >/dev/null 2>&1; then
+        log "Pulling $LLAMA_IMAGE"
+        docker pull -q "$LLAMA_IMAGE" >/dev/null
+    fi
+
+    ensure_volume
+
+    log "Checking Gemma 4 weights in $VOLUME_NAME"
+    if docker run --rm \
+        -v "$VOLUME_NAME:/models" \
+        -v "$FETCH_SCRIPT:/fetch-models.sh:ro" \
+        --entrypoint bash \
+        "$LLAMA_IMAGE" /fetch-models.sh; then
+        return 0
+    fi
+
+    die "Failed to prepare Gemma 4 weights; llama-cpp will not start"
+}
+
+main "$@"

--- a/scripts/open-webui-bootstrap.sh
+++ b/scripts/open-webui-bootstrap.sh
@@ -20,6 +20,14 @@ set -eu
 
 # Service name and port from compose.yaml; both containers sit on the ai network.
 LLAMA_URL="http://llama-cpp:8080/v1"
+# Model alias llama-cpp serves (LLAMA_ARG_ALIAS in compose.yaml).
+LLAMA_MODEL="gemma-4-e2b-it"
+# Marker row recording that the defaults below were seeded, so they are applied
+# once and never re-imposed - anything changed afterwards in Admin Settings
+# stays changed.
+DEFAULTS_MARKER="pi-pcloud.local_ai_defaults"
+# Bump when the defaults below change, to seed the new ones once.
+DEFAULTS_VERSION='"2"'
 
 compose() {
     (cd "$PROJECT_DIR" && docker compose "$@")
@@ -85,19 +93,86 @@ END
 SQL
 }
 
+# 't' once this version of the defaults has been seeded.
+defaults_applied() {
+    psql_owui -tAc \
+        "SELECT EXISTS (
+             SELECT 1 FROM config
+             WHERE key = '$DEFAULTS_MARKER' AND value::text = '$DEFAULTS_VERSION'
+         );" 2>/dev/null | tr -d ' \r\n'
+}
+
+# Open WebUI fires an extra, invisible LLM call per message for each of these:
+# a chat title, chat tags, follow-up suggestions, a search query rewrite. Against
+# a cloud API that is free; against a Pi generating ~10 tok/s it multiplies the
+# wait for the answer the user is actually looking at, several times over, all
+# competing for the same three CPU threads. Off by default here.
+apply_defaults() {
+    psql_owui -q <<SQL
+INSERT INTO config (key, value, updated_at) VALUES
+    ('task.title.enable',                'false'::json,          extract(epoch from now())::bigint),
+    ('task.tags.enable',                 'false'::json,          extract(epoch from now())::bigint),
+    ('task.follow_up.enable',            'false'::json,          extract(epoch from now())::bigint),
+    ('task.query.search.enable',         'false'::json,          extract(epoch from now())::bigint),
+    ('task.query.retrieval.enable',      'false'::json,          extract(epoch from now())::bigint),
+    ('task.autocomplete.enable',         'false'::json,          extract(epoch from now())::bigint),
+    ('memories.background_review.enable','false'::json,          extract(epoch from now())::bigint),
+    ('task.model.default',               '"$LLAMA_MODEL"'::json, extract(epoch from now())::bigint),
+    ('$DEFAULTS_MARKER',                 '$DEFAULTS_VERSION'::json, extract(epoch from now())::bigint)
+ON CONFLICT (key) DO UPDATE
+    SET value = EXCLUDED.value, updated_at = EXCLUDED.updated_at;
+SQL
+
+    # Built-in tools (time, memory, chats, notes, knowledge, channels) are on by
+    # default for every model, and their schemas are injected into the prompt of
+    # every message sent from the browser - about 5000 tokens, which is ~3
+    # minutes of prompt processing on this CPU before the model starts writing.
+    # A workspace entry for the model is the only place that default can be
+    # turned off, so create one. Attaching tools to a chat explicitly still
+    # works.
+    psql_owui -q <<SQL
+INSERT INTO model (id, user_id, base_model_id, name, meta, params, created_at, updated_at, is_active)
+SELECT
+    '$LLAMA_MODEL',
+    (SELECT id FROM "user" WHERE role = 'admin' ORDER BY created_at LIMIT 1),
+    NULL,
+    '$LLAMA_MODEL',
+    '{"capabilities": {"builtin_tools": false}}',
+    '{}',
+    extract(epoch from now())::bigint,
+    extract(epoch from now())::bigint,
+    true
+WHERE EXISTS (SELECT 1 FROM "user" WHERE role = 'admin')
+ON CONFLICT (id) DO UPDATE SET
+    meta = jsonb_set(
+        coalesce(model.meta::jsonb, '{}'::jsonb),
+        '{capabilities,builtin_tools}',
+        'false'::jsonb,
+        true
+    )::text,
+    updated_at = extract(epoch from now())::bigint;
+SQL
+}
+
 main() {
+    changed=0
+
     if ! container_is_running "pi-postgres"; then
-        log "postgres is not running; skipping Open WebUI connection bootstrap"
+        log "postgres is not running; skipping Open WebUI bootstrap"
         return 0
     fi
 
     wait_for_health_warning "pi-open-webui" 60 2 || true
 
     case "$(connection_present)" in
-        t)
-            return 0
-            ;;
+        t) ;;
         f)
+            log "Registering $LLAMA_URL as an Open WebUI connection"
+            if add_connection; then
+                changed=1
+            else
+                log "WARNING: failed to register the llama-cpp connection"
+            fi
             ;;
         *)
             log "WARNING: could not read Open WebUI config table; skipping"
@@ -105,13 +180,18 @@ main() {
             ;;
     esac
 
-    log "Registering $LLAMA_URL as an Open WebUI connection"
-    if ! add_connection; then
-        log "WARNING: failed to register the llama-cpp connection"
-        return 0
+    if [ "$(defaults_applied)" = "f" ]; then
+        log "Seeding low-latency defaults (title/tags/follow-up generation off)"
+        if apply_defaults; then
+            changed=1
+        else
+            log "WARNING: failed to seed Open WebUI defaults"
+        fi
     fi
 
-    log "Restarting open-webui to pick up the new connection"
+    [ "$changed" = "1" ] || return 0
+
+    log "Restarting open-webui to pick up the new configuration"
     compose restart open-webui >/dev/null 2>&1 || log "WARNING: could not restart open-webui"
     wait_for_health_warning "pi-open-webui" 90 2 || true
 }

--- a/scripts/open-webui-bootstrap.sh
+++ b/scripts/open-webui-bootstrap.sh
@@ -28,6 +28,13 @@ LLAMA_MODEL="gemma-4-e2b-it"
 DEFAULTS_MARKER="pi-pcloud.local_ai_defaults"
 # Bump when the defaults below change, to seed the new ones once.
 DEFAULTS_VERSION='"2"'
+# The text-to-speech settings carry their own marker, so bumping one group's
+# version never re-imposes the other's.
+TTS_MARKER="pi-pcloud.local_tts_defaults"
+TTS_VERSION='"1"'
+# Piper's OpenAI-compatible facade (config/piper), on the same ai network.
+TTS_BASE_URL="http://piper:8000/v1"
+TTS_VOICE="fr_FR-siwis-medium"
 
 compose() {
     (cd "$PROJECT_DIR" && docker compose "$@")
@@ -93,13 +100,31 @@ END
 SQL
 }
 
-# 't' once this version of the defaults has been seeded.
-defaults_applied() {
+# 't' once the given version of a settings group has been seeded.
+marker_present() {
     psql_owui -tAc \
         "SELECT EXISTS (
-             SELECT 1 FROM config
-             WHERE key = '$DEFAULTS_MARKER' AND value::text = '$DEFAULTS_VERSION'
+             SELECT 1 FROM config WHERE key = '$1' AND value::text = '$2'
          );" 2>/dev/null | tr -d ' \r\n'
+}
+
+# Point Open WebUI's read-aloud button at the local Piper container. Seeded, not
+# enforced: the engine has to be set somewhere for the feature to exist at all,
+# but this runs once, so switching back to the browser voice - or to another
+# voice - in Admin Settings sticks. Per-user voice choices in Settings > Audio
+# override the default below anyway, and Piper falls back to it when asked for a
+# voice it does not have.
+apply_tts_defaults() {
+    psql_owui -q <<SQL
+INSERT INTO config (key, value, updated_at) VALUES
+    ('audio.tts.engine',              '"openai"'::json,         extract(epoch from now())::bigint),
+    ('audio.tts.openai.api_base_url', '"$TTS_BASE_URL"'::json,  extract(epoch from now())::bigint),
+    ('audio.tts.model',               '"$TTS_VOICE"'::json,     extract(epoch from now())::bigint),
+    ('audio.tts.voice',               '"$TTS_VOICE"'::json,     extract(epoch from now())::bigint),
+    ('$TTS_MARKER',                   '$TTS_VERSION'::json,     extract(epoch from now())::bigint)
+ON CONFLICT (key) DO UPDATE
+    SET value = EXCLUDED.value, updated_at = EXCLUDED.updated_at;
+SQL
 }
 
 # Open WebUI fires an extra, invisible LLM call per message for each of these:
@@ -180,12 +205,21 @@ main() {
             ;;
     esac
 
-    if [ "$(defaults_applied)" = "f" ]; then
+    if [ "$(marker_present "$DEFAULTS_MARKER" "$DEFAULTS_VERSION")" = "f" ]; then
         log "Seeding low-latency defaults (title/tags/follow-up generation off)"
         if apply_defaults; then
             changed=1
         else
             log "WARNING: failed to seed Open WebUI defaults"
+        fi
+    fi
+
+    if [ "$(marker_present "$TTS_MARKER" "$TTS_VERSION")" = "f" ]; then
+        log "Pointing text-to-speech at Piper ($TTS_VOICE)"
+        if apply_tts_defaults; then
+            changed=1
+        else
+            log "WARNING: failed to seed Open WebUI text-to-speech settings"
         fi
     fi
 

--- a/scripts/open-webui-bootstrap.sh
+++ b/scripts/open-webui-bootstrap.sh
@@ -1,0 +1,119 @@
+#!/bin/sh
+# Registers the local llama-cpp backend as an Open WebUI connection.
+#
+# The OPENAI_API_BASE_URL / ENABLE_OPENAI_API variables on the open-webui
+# service are "PersistentConfig" ones: Open WebUI copies them into its database
+# the first time it starts and reads the database from then on, so on an
+# instance that already has connections configured the environment is ignored
+# and the model never appears in the picker. Hence this bootstrap.
+#
+# Open WebUI's connection API needs an admin session token, and logins go
+# through Authelia SSO (ENABLE_LOGIN_FORM=false), so there is no scriptable
+# credential to obtain one with - the config table is the practical route.
+#
+# Idempotent: it appends the connection only when missing, leaves any other
+# connection alone, and only restarts open-webui when it actually changed
+# something (the running process caches the config it loaded at startup).
+set -eu
+
+. "$(dirname "$0")/lib.sh"
+
+# Service name and port from compose.yaml; both containers sit on the ai network.
+LLAMA_URL="http://llama-cpp:8080/v1"
+
+compose() {
+    (cd "$PROJECT_DIR" && docker compose "$@")
+}
+
+psql_owui() {
+    compose exec -T postgres psql -v ON_ERROR_STOP=1 -U postgres -d open-webui "$@"
+}
+
+# 't' when the connection is already registered, or when Open WebUI has not
+# persisted its connection list yet - a fresh install seeds it straight from
+# the compose environment, which already points at llama-cpp.
+connection_present() {
+    psql_owui -tAc \
+        "SELECT coalesce(
+             (SELECT value::jsonb ? '$LLAMA_URL' FROM config WHERE key = 'openai.api_base_urls'),
+             true
+         );" 2>/dev/null | tr -d ' \r\n'
+}
+
+add_connection() {
+    # api_base_urls, api_keys and api_configs are parallel: the config for a URL
+    # is looked up by its index in the URL list, so all three have to grow
+    # together. api_keys is padded first in case it is short - llama-server
+    # takes no key anyway, it is unauthenticated on the internal ai network.
+    psql_owui -q <<SQL
+DO \$\$
+DECLARE
+    target text := '$LLAMA_URL';
+    urls   jsonb;
+    keys   jsonb;
+    idx    int;
+    stamp  bigint := extract(epoch from now())::bigint;
+BEGIN
+    SELECT value::jsonb INTO urls FROM config WHERE key = 'openai.api_base_urls';
+    IF urls IS NULL OR urls ? target THEN
+        RETURN;
+    END IF;
+
+    idx := jsonb_array_length(urls);
+
+    SELECT coalesce(value::jsonb, '[]'::jsonb) INTO keys FROM config WHERE key = 'openai.api_keys';
+    keys := coalesce(keys, '[]'::jsonb);
+    WHILE jsonb_array_length(keys) < idx LOOP
+        keys := keys || to_jsonb(''::text);
+    END LOOP;
+
+    UPDATE config SET value = (urls || to_jsonb(target))::json, updated_at = stamp
+        WHERE key = 'openai.api_base_urls';
+    UPDATE config SET value = (keys || to_jsonb(''::text))::json, updated_at = stamp
+        WHERE key = 'openai.api_keys';
+    UPDATE config SET value = jsonb_set(
+            coalesce(value::jsonb, '{}'::jsonb),
+            ARRAY[idx::text],
+            '{"enable": true, "connection_type": "local", "tags": [], "prefix_id": "", "model_ids": []}'::jsonb,
+            true
+        )::json, updated_at = stamp
+        WHERE key = 'openai.api_configs';
+    UPDATE config SET value = 'true'::json, updated_at = stamp
+        WHERE key = 'openai.enable';
+END
+\$\$;
+SQL
+}
+
+main() {
+    if ! container_is_running "pi-postgres"; then
+        log "postgres is not running; skipping Open WebUI connection bootstrap"
+        return 0
+    fi
+
+    wait_for_health_warning "pi-open-webui" 60 2 || true
+
+    case "$(connection_present)" in
+        t)
+            return 0
+            ;;
+        f)
+            ;;
+        *)
+            log "WARNING: could not read Open WebUI config table; skipping"
+            return 0
+            ;;
+    esac
+
+    log "Registering $LLAMA_URL as an Open WebUI connection"
+    if ! add_connection; then
+        log "WARNING: failed to register the llama-cpp connection"
+        return 0
+    fi
+
+    log "Restarting open-webui to pick up the new connection"
+    compose restart open-webui >/dev/null 2>&1 || log "WARNING: could not restart open-webui"
+    wait_for_health_warning "pi-open-webui" 90 2 || true
+}
+
+main "$@"

--- a/scripts/uptime-kuma-bootstrap.py
+++ b/scripts/uptime-kuma-bootstrap.py
@@ -148,7 +148,13 @@ GROUPS = [
         "retry": 120,
         "maxretries": 2,
         "resend": 0,
-        "containers": ["pi-n8n", "pi-n8n-runners", "pi-open-webui", "pi-llama-cpp"],
+        "containers": [
+            "pi-n8n",
+            "pi-n8n-runners",
+            "pi-open-webui",
+            "pi-llama-cpp",
+            "pi-piper",
+        ],
     },
     {
         "name": "External Chain",

--- a/scripts/uptime-kuma-bootstrap.py
+++ b/scripts/uptime-kuma-bootstrap.py
@@ -148,7 +148,7 @@ GROUPS = [
         "retry": 120,
         "maxretries": 2,
         "resend": 0,
-        "containers": ["pi-n8n", "pi-n8n-runners", "pi-open-webui"],
+        "containers": ["pi-n8n", "pi-n8n-runners", "pi-open-webui", "pi-llama-cpp"],
     },
     {
         "name": "External Chain",


### PR DESCRIPTION
Open WebUI had no inference backend. This adds one, plus French text-to-speech, and fixes the two things that made the first version unusable in practice.

## llama.cpp rather than Ollama

Ollama wraps this same engine and adds a model registry, per-request runner processes and model swapping — none of which a box with room for one resident model can use. Going direct is faster on ARM CPU, one process instead of two, and speaks the OpenAI API Open WebUI already talks.

Model is Google's **QAT Q4_0** build of Gemma 4 E2B — quantisation-aware training recovers most of the quality plain Q4_0 loses, and llama.cpp repacks Q4_0 into the Cortex-A76's i8mm/dotprod kernels.

Measured on a Pi 5 (16GB, stack running):

| | |
|---|---|
| baseline | 5.3 tok/s |
| **+ speculative decoding off the MTP head** | **10.6 tok/s** |
| prompt processing | ~40 tok/s |
| resident / load time | ~3.7GB / ~13s |

Three threads pinned to cores 1-3: the fourth measured no faster (generation is memory-bandwidth bound) and core 0 stays free for Traefik and DNS. Quantising the KV cache was *slower* than f16 — Gemma's sliding-window attention keeps it small. Vision and audio input are enabled via the multimodal projector.

The `ai` network is internal, so the container cannot fetch its own weights: `scripts/llama-cpp-pre-start.sh` seeds them into a Docker volume on the NVMe root (not the rotational USB drive `DATA_LOCATION` points at) before the stack starts, idempotently.

## Two fixes that made it actually usable

**The model never appeared in the picker.** `OPENAI_API_BASE_URL` is an Open WebUI *PersistentConfig* variable: it seeds the database on first start and is ignored afterwards. On an instance that already has connections, the environment does nothing. `scripts/open-webui-bootstrap.sh` appends the connection to the stored list instead, leaving any other connection untouched.

**A two-word question took minutes and pegged every core.** Three multipliers, all on prompt size:

- Open WebUI injects its built-in tools (time, memory, chats, notes, knowledge, channels) into every message sent from the browser — ~5000 tokens of schemas, about three minutes of prompt processing before generation starts. The capability defaults to on and can only be turned off per model.
- Title, tag, follow-up and search-query generation each fire another invisible LLM call per message.
- llama-server defaults to several slots and runs them concurrently: two requests each generated at ~5 tok/s instead of one at ~10.

Thinking is off too — Gemma 4 spent ~500 tokens reasoning before the first visible word. Note `--reasoning-budget 0` is **not** the switch for that: it closes the thinking channel without telling the model, which then writes its reasoning into the visible answer. The chat template reads `enable_thinking`, so that goes through `--chat-template-kwargs`.

Same question after: **3.1s end to end**.

## French text-to-speech

`piper`, built from `config/piper/` on top of [OHF-Voice/piper1-gpl](https://github.com/OHF-Voice/piper1-gpl). Upstream publishes no image and its HTTP server speaks its own protocol, so the image adds a small OpenAI-compatible facade (`/v1/audio/speech`, `/v1/audio/voices`, `/v1/audio/models`) over Piper's Python API. The aarch64 wheel means nothing compiles at build time.

Three French voices plus one English baked into the image (~180MB), since the `ai` network is internal. ~5 seconds of speech per second of CPU, 215MB resident, 1.4s for a short sentence end to end.

## Seeded, never enforced

Every Open WebUI setting this touches is written once behind a marker row, with separate markers for the latency group and the TTS group. Anything changed afterwards in Admin Settings stays changed.

## Verified on the target hardware

- `gemma-4-e2b-it` resolves in Open WebUI's model list, answers in ~3s
- Image input works (fed it a red square, it said "The image shows a red square")
- TTS returns audio through Open WebUI's own endpoint, all four voices listed
- Both bootstrap scripts are no-ops on a second run
- CI excludes both new services and drops the dependency; `compose config` and `yamllint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)