### PR TITLE
feat(homepage): show llama-cpp and piper in the AI section

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1693,6 +1693,12 @@ services:
       test: ["CMD", "curl", "-fsS", "http://localhost:8080/health"]
       start_period: 120s
       start_interval: 5s
+    labels:
+      # Same as piper: an API behind open-webui, so no href, just health.
+      - "homepage.group=AI"
+      - "homepage.name=llama.cpp"
+      - "homepage.description=Gemma 4 E2B inference"
+      - "homepage.icon=mdi-brain"
     deploy: *cpu-request-xlarge
     cpuset: "1-3"
     # Weights are mmap'd, and the cgroup counts those pages: 3.4G of model plus
@@ -1727,6 +1733,14 @@ services:
       # python:3.12-slim ships no curl or wget, but python is the point of it.
       test: ["CMD", "python3", "-c", "import urllib.request as r; r.urlopen('http://localhost:8000/health').read()"]
       start_period: 30s
+    labels:
+      # No homepage.href: this is an API for open-webui, there is no page to
+      # open. The card still reports the container's health. mdi- icons because
+      # dashboard-icons has nothing for piper.
+      - "homepage.group=AI"
+      - "homepage.name=Piper"
+      - "homepage.description=French text-to-speech"
+      - "homepage.icon=mdi-text-to-speech"
     deploy: *cpu-request-small
     # Same three cores as llama-cpp, leaving core 0 to traefik and DNS.
     cpuset: "1-3"


### PR DESCRIPTION
`Tools > AI` showed only the Open WebUI card, even though two more containers back it. Neither `llama-cpp` nor `piper` carried `homepage.*` labels.

No `homepage.href` on either: both are APIs Open WebUI talks to, with no page to open — the same situation as the existing `tailscale` card, which also has none. The card still reports container health, which is the useful part for a backend service. `mdi-` icons because dashboard-icons has no `piper` or `llama.cpp` entry, and `settings.yaml` already uses the `mdi-` set for its group icons.

Verified against Homepage's own discovery API on the running stack:

```
/Services/Tools/AI :: llama.cpp   | container=pi-llama-cpp | href=None
/Services/Tools/AI :: Open WebUI  | container=pi-open-webui | href=https://ai.…
/Services/Tools/AI :: Piper       | container=pi-piper      | href=None
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)