### PR TITLE
chore(deps): bump llama.cpp server to b10481

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1632,7 +1632,7 @@ services:
   # instead of two, and speaks the OpenAI API open-webui already talks.
   llama-cpp:
     <<: *service-defaults
-    image: ghcr.io/ggml-org/llama.cpp:server-b10454
+    image: ghcr.io/ggml-org/llama.cpp:server-b10481
     container_name: pi-llama-cpp
     networks:
       - ai

--- a/scripts/llama-cpp-pre-start.sh
+++ b/scripts/llama-cpp-pre-start.sh
@@ -11,7 +11,7 @@ set -eu
 . "$(dirname "$0")/lib.sh"
 
 # Keep in sync with the llama-cpp image tag in compose.yaml.
-LLAMA_IMAGE="${LLAMA_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-b10454}"
+LLAMA_IMAGE="${LLAMA_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-b10481}"
 FETCH_SCRIPT="$PROJECT_DIR/config/llama-cpp/fetch-models.sh"
 
 # compose prefixes volume names with the project name (the project directory


### PR DESCRIPTION
Bumps the llama.cpp server image from `b10454` to `b10481`, in both places that pin it — the `llama-cpp` service in `compose.yaml` and the `LLAMA_IMAGE` default in `scripts/llama-cpp-pre-start.sh`, which the comment there requires be kept in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)