### PR TITLE
fix(homepage): move Security below the media groups and to one column

### DIFF
--- a/config/homepage/settings.yaml
+++ b/config/homepage/settings.yaml
@@ -46,10 +46,6 @@ layout:
       style: row
       columns: 1
       icon: mdi-database
-    Security:
-      style: row
-      columns: 2
-      icon: mdi-shield-key
     Download:
       style: row
       columns: 1
@@ -62,6 +58,10 @@ layout:
       style: row
       columns: 2
       icon: mdi-video
+    Security:
+      style: row
+      columns: 1
+      icon: mdi-shield-key
     Tools:
       style: row
       columns: 2


### PR DESCRIPTION
The `Security` group holds a single card (Vaultwarden), so a two-column row left half the width empty. And sitting between `Database` and `Download` it split the groups that are read together.

One column, placed after `Media`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)