### PR TITLE
feat(ai): one DEFAULT_LANGUAGE variable for the whole stack

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,6 +1,12 @@
 # --- Personal Configuration ---
 HOST_NAME=
 TIMEZONE=
+# Language for anything the stack has to pick a language for, as a BCP 47 tag:
+# the Open WebUI interface, and which Piper voice reads answers aloud. Defaults
+# to en-US; fr-FR is the other one with voices shipped. Any other tag falls back
+# rather than failing, and needs a voice added to config/piper/Dockerfile to be
+# read aloud properly.
+DEFAULT_LANGUAGE=
 ADMIN_USER=
 PASSWORD=
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you're deciding between approaches, here's the short version:
 | **Network & Security** | Traefik (reverse proxy), Tailscale/Headscale (VPN), Authelia (SSO), LLDAP (user directory) |
 | **DNS & Filtering** | Pi-hole (ad-blocking), Unbound (recursive DNS) |
 | **Download** | qBittorrent (torrent client), Prowlarr (indexer manager), Kapowarr (comics manager), FlareSolverr (Cloudflare solver), Gluetun (VPN kill-switch gateway) |
-| **AI** | Open WebUI (chat interface), llama.cpp (local Gemma 4 E2B inference, CPU-only), Piper (French text-to-speech) |
+| **AI** | Open WebUI (chat interface), llama.cpp (local Gemma 4 E2B inference, CPU-only), Piper (text-to-speech, French voices) |
 | **Monitoring & Backup** | Beszel (monitoring), Backrest (restic backups), Dockhand (container management) |
 | **Infrastructure** | PostgreSQL, Redis, ddns-updater |
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1725,9 +1725,13 @@ services:
     expose:
       - 8000
     environment:
-      # Used when a request asks for a voice that does not exist here - which
-      # includes every OpenAI voice name open-webui defaults to (alloy, echo).
-      - PIPER_DEFAULT_VOICE=fr_FR-siwis-medium
+      # open-webui defaults to OpenAI voice names (alloy, echo), none of which
+      # exist here, so in practice this is the voice. Derived from the stack-wide
+      # DEFAULT_LANGUAGE rather than named, so moving the stack to another
+      # language does not mean knowing a Piper voice id; set PIPER_DEFAULT_VOICE
+      # to name one outright. A voice has to be in the image to be picked - see
+      # the VOICES build arg in config/piper/Dockerfile.
+      - PIPER_DEFAULT_LANGUAGE=${DEFAULT_LANGUAGE:-en-US}
     healthcheck:
       <<: *healthcheck-relaxed
       # python:3.12-slim ships no curl or wget, but python is the point of it.
@@ -1739,7 +1743,7 @@ services:
       # dashboard-icons has nothing for piper.
       - "homepage.group=AI"
       - "homepage.name=Piper"
-      - "homepage.description=French text-to-speech"
+      - "homepage.description=Text-to-speech, French by default"
       - "homepage.icon=mdi-text-to-speech"
     deploy: *cpu-request-small
     # Same three cores as llama-cpp, leaving core 0 to traefik and DNS.
@@ -1779,6 +1783,9 @@ services:
       # No Ollama in the stack; left on, open-webui probes localhost:11434 on
       # every start and on the model list of every page load.
       - ENABLE_OLLAMA_API=false
+      # Interface language for anyone who has not picked one themselves. Same
+      # BCP 47 tag as the rest of the stack; per-user choices override it.
+      - DEFAULT_LOCALE=${DEFAULT_LANGUAGE:-en-US}
     volumes:
       - open_webui_data:/app/backend/data
       - ${DATA_LOCATION:-./data}/authelia-config/secrets/oidc_open-webui_secret.txt:/run/secrets/oidc_open-webui_secret:ro

--- a/config/piper/openai_api.py
+++ b/config/piper/openai_api.py
@@ -32,7 +32,13 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(mess
 log = logging.getLogger("piper-openai")
 
 VOICE_DIR = Path(os.environ.get("PIPER_VOICE_DIR", "/voices"))
-DEFAULT_VOICE = os.environ.get("PIPER_DEFAULT_VOICE", "fr_FR-siwis-medium")
+# The stack-wide DEFAULT_LANGUAGE, as a BCP 47 tag. A voice is picked to match it
+# rather than named here, so that the language of the whole stack is one variable
+# in .env and not a voice id somebody has to know exists.
+DEFAULT_LANGUAGE = os.environ.get("PIPER_DEFAULT_LANGUAGE", "en-US").strip()
+# Escape hatch: naming a voice outright wins over the language match, which is
+# how you get fr_FR-tom-medium rather than whichever French voice sorts first.
+EXPLICIT_VOICE = os.environ.get("PIPER_DEFAULT_VOICE", "").strip()
 
 app = FastAPI(title="Piper OpenAI-compatible TTS")
 
@@ -44,6 +50,41 @@ _synth_lock = threading.Lock()
 def available_voices() -> list[str]:
     """Voice ids, taken from the .onnx files baked into the image."""
     return sorted(p.stem for p in VOICE_DIR.rglob("*.onnx"))
+
+
+def resolve_default_voice() -> str:
+    """Best voice in the image for DEFAULT_LANGUAGE, widening until something fits.
+
+    Piper names voices `fr_FR-siwis-medium`, so an en-US/fr-FR tag maps onto the
+    first segment. The two fallbacks matter because DEFAULT_LANGUAGE is a
+    stack-wide setting: someone setting de-DE has not necessarily rebuilt this
+    image with a German voice, and answering in the wrong language beats failing
+    every read-aloud with a 500.
+    """
+    voices = available_voices()
+    if not voices:
+        return ""
+    if EXPLICIT_VOICE:
+        return EXPLICIT_VOICE
+
+    region = DEFAULT_LANGUAGE.replace("-", "_")
+    exact = [v for v in voices if v.startswith(f"{region}-")]
+    if exact:
+        return exact[0]
+
+    # fr-BE with only fr_FR voices baked in: same language, other region.
+    language = region.split("_")[0]
+    same_language = [v for v in voices if v.startswith(f"{language}_")]
+    if same_language:
+        log.info("no %s voice, using %s", DEFAULT_LANGUAGE, same_language[0])
+        return same_language[0]
+
+    log.warning("no voice for %s in %s, using %s - rebuild with the VOICES build "
+                "arg to add one", DEFAULT_LANGUAGE, [v for v in voices], voices[0])
+    return voices[0]
+
+
+DEFAULT_VOICE = resolve_default_voice()
 
 
 def voice_path(name: str) -> Path | None:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -295,7 +295,27 @@ after a database restore:
 sh scripts/open-webui-bootstrap.sh
 ```
 
-**French text-to-speech.** The read-aloud button goes through `piper`, built
+**Language.** One `.env` variable, `DEFAULT_LANGUAGE`, sets the language of
+everything in the stack that has to choose one, as a BCP 47 tag. It defaults to
+`en-US`; this is the only place to change it:
+
+| It drives | How |
+|-----------|-----|
+| Open WebUI's interface | `DEFAULT_LOCALE`, for users who have not picked a language themselves |
+| Which Piper voice reads answers aloud | matched against the voices baked into the image |
+
+`fr-FR` and `en-US` are the two tags with voices shipped. Anything else still
+works - the interface has its own translations, and Piper picks the closest
+voice it has (`fr-BE` finds `fr_FR-siwis-medium`; `de-DE` warns in the log and
+uses English until you add a German voice to `VOICES` in
+`config/piper/Dockerfile`). To name a voice outright instead of matching the
+language, set `PIPER_DEFAULT_VOICE` on the service.
+
+Changing it later is one variable and a restart: the seeding markers carry the
+language, so `pi-pcloud.local_tts_defaults` moves from `2-en-US` to `2-fr-FR` and
+re-seeds once. A voice you then pick in Admin Settings stays picked.
+
+**Text-to-speech.** The read-aloud button goes through `piper`, built
 from `config/piper/` on top of [OHF-Voice/piper1-gpl](https://github.com/OHF-Voice/piper1-gpl).
 Upstream publishes no image and its HTTP server speaks its own protocol, so the
 image adds `config/piper/openai_api.py`, a small OpenAI-compatible facade
@@ -309,9 +329,11 @@ WebUI's "OpenAI" TTS engine calls. Voices are baked into the image:
 | `fr_FR-upmc-medium` | French, female, different timbre |
 | `en_US-lessac-medium` | English, so English text is not read with a French phonemiser |
 
-Roughly five seconds of speech per second of CPU, ~215MB resident. Pick a voice
-per user in **Settings → Audio**; it overrides the default, and a request for a
-voice Piper does not have falls back rather than failing. To add voices, extend
+Roughly five seconds of speech per second of CPU, ~215MB resident. The default
+voice is not named on the service - it is matched against `DEFAULT_LANGUAGE`
+above, because open-webui asks for OpenAI's own voice names (`alloy`, `echo`),
+none of which exist here, so the fallback *is* the voice in practice. Pick a
+voice per user in **Settings → Audio**; it overrides the default. To add voices, extend
 `VOICES` in `config/piper/Dockerfile` (the catalogue is
 [rhasspy/piper-voices](https://huggingface.co/rhasspy/piper-voices)) and rebuild
 with `docker compose build piper`. To go back to the browser's own voices, set

--- a/scripts/open-webui-bootstrap.sh
+++ b/scripts/open-webui-bootstrap.sh
@@ -18,6 +18,14 @@ set -eu
 
 . "$(dirname "$0")/lib.sh"
 
+# The stack-wide language, as a BCP 47 tag - the same .env variable compose
+# passes to piper and open-webui. Read from the file rather than the environment
+# because this script writes to the database directly, and so never sees the
+# variables compose expands. Everything below that has to pick a language picks
+# this one.
+DEFAULT_LANGUAGE="$(get_env_value DEFAULT_LANGUAGE)"
+[ -n "$DEFAULT_LANGUAGE" ] || DEFAULT_LANGUAGE="en-US"
+
 # Service name and port from compose.yaml; both containers sit on the ai network.
 LLAMA_URL="http://llama-cpp:8080/v1"
 # Model alias llama-cpp serves (LLAMA_ARG_ALIAS in compose.yaml).
@@ -31,10 +39,25 @@ DEFAULTS_VERSION='"2"'
 # The text-to-speech settings carry their own marker, so bumping one group's
 # version never re-imposes the other's.
 TTS_MARKER="pi-pcloud.local_tts_defaults"
-TTS_VERSION='"1"'
+# The language is part of the version, so changing DEFAULT_LANGUAGE re-seeds the
+# voice once and re-running with the same language keeps doing nothing.
+TTS_VERSION="\"2-$DEFAULT_LANGUAGE\""
 # Piper's OpenAI-compatible facade (config/piper), on the same ai network.
 TTS_BASE_URL="http://piper:8000/v1"
-TTS_VOICE="fr_FR-siwis-medium"
+case "$DEFAULT_LANGUAGE" in
+    fr*) TTS_VOICE="fr_FR-siwis-medium" ;;
+    # Anything else gets the English voice, which is also what piper falls back
+    # to on its own when no voice matches the language - its baked-in list sorts
+    # en_US before fr_FR. Seeding the same name keeps Admin Settings > Audio
+    # showing the voice that will actually answer, rather than a name that is
+    # silently substituted on every request.
+    *)   TTS_VOICE="en_US-lessac-medium" ;;
+esac
+# The interface language. DEFAULT_LOCALE is PersistentConfig like the rest, so
+# compose only reaches an instance that has never started; here the database
+# still holds Open WebUI's own empty default, which means "follow the browser".
+LOCALE_MARKER="pi-pcloud.default_locale"
+LOCALE_VERSION="\"1-$DEFAULT_LANGUAGE\""
 
 compose() {
     (cd "$PROJECT_DIR" && docker compose "$@")
@@ -127,6 +150,20 @@ ON CONFLICT (key) DO UPDATE
 SQL
 }
 
+# Set the interface language for anyone who has not picked one in their own
+# settings. Seeded once per language, like the two above: choosing another
+# language in Settings > Interface sticks, and so does an admin setting the
+# default back to blank to follow each visitor's browser instead.
+apply_locale_default() {
+    psql_owui -q <<SQL
+INSERT INTO config (key, value, updated_at) VALUES
+    ('ui.default_locale', '"$DEFAULT_LANGUAGE"'::json, extract(epoch from now())::bigint),
+    ('$LOCALE_MARKER',    '$LOCALE_VERSION'::json,     extract(epoch from now())::bigint)
+ON CONFLICT (key) DO UPDATE
+    SET value = EXCLUDED.value, updated_at = EXCLUDED.updated_at;
+SQL
+}
+
 # Open WebUI fires an extra, invisible LLM call per message for each of these:
 # a chat title, chat tags, follow-up suggestions, a search query rewrite. Against
 # a cloud API that is free; against a Pi generating ~10 tok/s it multiplies the
@@ -211,6 +248,15 @@ main() {
             changed=1
         else
             log "WARNING: failed to seed Open WebUI defaults"
+        fi
+    fi
+
+    if [ "$(marker_present "$LOCALE_MARKER" "$LOCALE_VERSION")" = "f" ]; then
+        log "Setting the default interface language to $DEFAULT_LANGUAGE"
+        if apply_locale_default; then
+            changed=1
+        else
+            log "WARNING: failed to seed the Open WebUI default language"
         fi
     fi
 


### PR DESCRIPTION
The stack's language was spread across places nobody would think to look: a Piper voice id hardcoded on the service, another copy of it in the seeding script, and an Open WebUI interface that followed whatever browser happened to connect. Moving to another language meant knowing that `fr_FR-siwis-medium` is a thing that exists.

One `.env` variable now sets all of it, as a BCP 47 tag:

| It drives | How |
|-----------|-----|
| Open WebUI's interface | `DEFAULT_LOCALE`; a per-user choice still overrides it |
| Which Piper voice reads answers aloud | matched against the voices baked into the image |

The Piper service is handed the **language**, not a voice. `config/piper/openai_api.py` matches it against what is in the image, widening from exact tag → same language → whatever is present, rather than failing a read-aloud with a 500. `PIPER_DEFAULT_VOICE` still names one outright.

This matters more than it looks, because open-webui always asks for OpenAI's own voice names (`alloy`, `echo`), none of which exist here — so the fallback *is* the voice in practice.

The TTS seeding marker carries the language (`pi-pcloud.local_tts_defaults` → `2-fr-FR`), so changing the variable re-seeds the voice exactly once and re-running with the same language keeps doing nothing. A voice picked in Admin Settings afterwards stays picked.

Defaults to `en-US`; `fr-FR` is the other tag with voices shipped. Anything else falls back rather than failing.

Touches `compose.yaml` and `scripts/open-webui-bootstrap.sh` alongside #210 and #211 — expect small merge conflicts depending on order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)