### PR TITLE
feat(ai): local speech-to-text on Parakeet, wired to Open WebUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you're deciding between approaches, here's the short version:
 | **Network & Security** | Traefik (reverse proxy), Tailscale/Headscale (VPN), Authelia (SSO), LLDAP (user directory) |
 | **DNS & Filtering** | Pi-hole (ad-blocking), Unbound (recursive DNS) |
 | **Download** | qBittorrent (torrent client), Prowlarr (indexer manager), Kapowarr (comics manager), FlareSolverr (Cloudflare solver), Gluetun (VPN kill-switch gateway) |
-| **AI** | Open WebUI (chat interface), llama.cpp (local Gemma 4 E2B inference, CPU-only), Piper (text-to-speech, French voices) |
+| **AI** | Open WebUI (chat interface), llama.cpp (local Gemma 4 E2B inference, CPU-only), Piper (text-to-speech, French voices), Parakeet (multilingual speech-to-text) |
 | **Monitoring & Backup** | Beszel (monitoring), Backrest (restic backups), Dockhand (container management) |
 | **Infrastructure** | PostgreSQL, Redis, ddns-updater |
 

--- a/compose.test.yaml
+++ b/compose.test.yaml
@@ -57,6 +57,11 @@ services:
     # stack depends on it being up.
     profiles: [ci-excluded]
 
+  parakeet:
+    # Same as piper: the build bakes in ~660MB of Parakeet weights, and nothing
+    # else in the stack depends on it being up.
+    profiles: [ci-excluded]
+
   # --- open-webui: run without the excluded inference backend ---
   open-webui:
     # depends_on must be reset, not merged: compose would otherwise pull

--- a/compose.yaml
+++ b/compose.yaml
@@ -1695,6 +1695,70 @@ services:
     mem_limit: 512m
     oom_score_adj: *oom-score-deprioritize
 
+  # Speech-to-text for open-webui's microphone button.
+  #
+  # Open WebUI ships its own faster-whisper, but it runs inside the open-webui
+  # container - capped at 1g and already sitting at ~730MB - so the model has to
+  # stay small enough to be bad. On 113s of read French (FLEURS fr_fr) over this
+  # Pi's three cores it scored 20.2% WER at 0.95x realtime with the default
+  # `base`; `small` reached 12.5% at 1.25x and `medium` 4.9% at 3.99x, the last
+  # two needing 1-2.7GB the web UI has no room for.
+  #
+  # Parakeet is a TDT model: the decoder is a small joint network stepped once
+  # per frame rather than an autoregressive LM, so it lands whisper-medium's
+  # accuracy at a fraction of the cost - 8.7% WER at 0.17x realtime here, which
+  # is a dictated sentence coming back in well under a second. It punctuates and
+  # capitalises, and it has no language setting at all: it covers 25 European
+  # languages and picks one acoustically, so nothing needs configuring to dictate
+  # in one language today and another tomorrow. The numbers above were taken on
+  # French because that is what gets dictated here, not because it is a limit.
+  #
+  # Built here for the same reason as piper: upstream publishes no image, and
+  # onnx-asr has no HTTP server at all - see config/parakeet/openai_api.py.
+  parakeet:
+    <<: *service-defaults
+    build:
+      context: ./config/parakeet
+      dockerfile: Dockerfile
+    image: pi-parakeet:local
+    container_name: pi-parakeet
+    networks:
+      - ai
+    expose:
+      - 8000
+    environment:
+      # int8, the quantization baked into the image by the Dockerfile's build
+      # arg of the same name. fp32 is the better model - 4.5% WER against 8.7% -
+      # but it is 2.3GB resident instead of 1.2GB and a ~2.5GB download in the
+      # image; switching means rebuilding with --build-arg PARAKEET_QUANTIZATION=
+      # so that the weights loaded are the weights present.
+      - PARAKEET_QUANTIZATION=int8
+      # Matches the cpuset below; onnxruntime would otherwise size its thread
+      # pool from the host's four cores and oversubscribe the cgroup.
+      - PARAKEET_THREADS=3
+    healthcheck:
+      <<: *healthcheck-relaxed
+      # python:3.12-slim ships no curl or wget, same as piper. /health is 503
+      # until the model is resident, which takes ~5s from start.
+      test: ["CMD", "python3", "-c", "import urllib.request as r; r.urlopen('http://localhost:8000/health').read()"]
+      start_period: 60s
+    labels:
+      # No homepage.href: an API for open-webui, like piper, so the card only
+      # reports health. mdi- because dashboard-icons has nothing for parakeet.
+      - "homepage.group=AI"
+      - "homepage.name=Parakeet"
+      - "homepage.description=Multilingual speech-to-text"
+      - "homepage.icon=mdi-microphone-message"
+    deploy: *cpu-request-small
+    # Same three cores as llama-cpp and piper, leaving core 0 to traefik and DNS.
+    cpuset: "1-3"
+    # ~1.2GB resident for the int8 weights and the onnxruntime arena, plus room
+    # for the encoder's working set on a full transcription window (~1.4GB
+    # measured). The headroom is what stops a long upload from being an OOM:
+    # before openai_api.py windowed them, a 120s pass went past 2GB.
+    mem_limit: 2560m
+    oom_score_adj: *oom-score-deprioritize
+
   open-webui:
     <<: *service-defaults
     image: ghcr.io/open-webui/open-webui:v0.11.0
@@ -1729,6 +1793,22 @@ services:
       # Interface language for anyone who has not picked one themselves. Same
       # BCP 47 tag as the rest of the stack; per-user choices override it.
       - DEFAULT_LOCALE=${DEFAULT_LANGUAGE:-en-US}
+      # Speech-to-text on the parakeet sidecar rather than the faster-whisper
+      # that ships inside this container - see that service for the numbers.
+      # These are PersistentConfig, so they only take on an instance that has
+      # never started: they are what makes a fresh install come up dictating
+      # correctly, and scripts/open-webui-bootstrap.sh carries the same values
+      # to instances whose database already holds Open WebUI's own defaults.
+      #
+      # The base URL is not optional. Open WebUI defaults it to
+      # OPENAI_API_BASE_URL, which here is llama-cpp - so leaving it out would
+      # point the microphone at the chat model.
+      - AUDIO_STT_ENGINE=openai
+      - AUDIO_STT_OPENAI_API_BASE_URL=http://parakeet:8000/v1
+      - AUDIO_STT_MODEL=parakeet-tdt-0.6b-v3
+      # Required by the client, ignored by the facade: the ai network is
+      # internal and parakeet authenticates nobody, same as llama-cpp and piper.
+      - AUDIO_STT_OPENAI_API_KEY=parakeet
     volumes:
       - open_webui_data:/app/backend/data
       - ${DATA_LOCATION:-./data}/authelia-config/secrets/oidc_open-webui_secret.txt:/run/secrets/oidc_open-webui_secret:ro

--- a/config/parakeet/Dockerfile
+++ b/config/parakeet/Dockerfile
@@ -1,0 +1,62 @@
+# Parakeet TDT 0.6B v3 (NVIDIA) behind an OpenAI-compatible facade.
+#
+# Speech-to-text for open-webui's microphone button. Open WebUI ships its own
+# faster-whisper, but it runs inside the open-webui container - which is capped
+# at 1g and already sits at ~730MB - so any model worth the upgrade OOMs the web
+# UI along with it. Splitting it out is the same move piper made for TTS, and it
+# lets the model be sized against its own limit.
+#
+# Whisper was measured and dropped: on 113s of read French (FLEURS fr_fr), on
+# this Pi's three cores, faster-whisper scored 20.2% WER at 0.95x realtime for
+# base, 12.5% at 1.25x for small and 4.9% at 3.99x for medium. Parakeet is a TDT
+# model - the decoder is a small joint network stepped once per frame, not an
+# autoregressive LM - so it gets whisper-medium's accuracy at a fraction of the
+# cost: 4.5% WER at 0.30x realtime in fp32, 8.7% at 0.17x in int8.
+FROM python:3.12-slim
+
+# int8 by default: 8.7% WER against fp32's 4.5%, but 1.2GB resident instead of
+# 2.3GB and a ~660MB model in the image instead of ~2.5GB. Build with
+# --build-arg PARAKEET_QUANTIZATION= (empty) for fp32; the runtime default below
+# follows this, so the weights baked in are the weights loaded.
+ARG PARAKEET_QUANTIZATION=int8
+
+# Pinned like every other image here. onnx-asr is the runtime wrapper (it owns
+# the mel frontend and the TDT decode loop); onnxruntime ships an aarch64 wheel,
+# so nothing is compiled.
+ARG ONNX_ASR_VERSION=0.12.0
+
+# Uploads arrive as whatever the browser's MediaRecorder produced - webm/opus,
+# mp4, or an mp3 open-webui transcoded - and onnx-asr only reads wav. ffmpeg is
+# the decoder; see openai_api.py.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV HF_HOME=/models \
+    PARAKEET_QUANTIZATION=${PARAKEET_QUANTIZATION} \
+    PYTHONUNBUFFERED=1
+
+RUN pip install --no-cache-dir \
+        "onnx-asr[cpu,hub]==${ONNX_ASR_VERSION}" \
+        "fastapi>=0.115,<1" \
+        "uvicorn>=0.34,<1" \
+        "python-multipart>=0.0.9,<1"
+
+# Baked into the image rather than fetched at start, like piper's voices: the ai
+# network is internal and a container that has to reach huggingface.co before it
+# can answer is a container that breaks when the WAN does. Loading the model is
+# also the build's own smoke test - a bad quantization arg fails here, not at
+# three in the morning.
+RUN python3 -c "import onnx_asr, os; \
+onnx_asr.load_model('nemo-parakeet-tdt-0.6b-v3', \
+                    quantization=os.environ['PARAKEET_QUANTIZATION'] or None)"
+
+# Nothing above needs the network again, and a stray download at runtime would
+# stall the microphone button rather than fail loudly.
+ENV HF_HUB_OFFLINE=1
+
+COPY openai_api.py /app/openai_api.py
+WORKDIR /app
+
+EXPOSE 8000
+CMD ["uvicorn", "openai_api:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "1"]

--- a/config/parakeet/openai_api.py
+++ b/config/parakeet/openai_api.py
@@ -1,0 +1,184 @@
+"""OpenAI-compatible STT facade over Parakeet TDT 0.6B v3 (onnx-asr).
+
+Open WebUI's "OpenAI" speech-to-text engine posts the recording to one endpoint
+on its configured base URL, so that is what this serves:
+
+    POST /v1/audio/transcriptions   multipart: file, model, language -> {"text": ...}
+
+`language` is accepted and ignored. Parakeet v3 has no language conditioning -
+it was trained on 25 European languages and picks one acoustically - which is
+the point here: whisper's failure mode on a short French clip is to decide the
+audio is English and transliterate it, and there is no such decision to get
+wrong. Nothing has to be configured when someone dictates a sentence in English.
+
+Transcription is CPU-bound and holds the GIL, hence the single worker and the
+lock: on this Pi the point is to never take more than the three cores llama-cpp
+is already sharing.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import threading
+from contextlib import asynccontextmanager
+
+import numpy as np
+import onnx_asr
+import onnxruntime as ort
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from fastapi.responses import JSONResponse
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("parakeet-openai")
+
+MODEL_NAME = os.environ.get("PARAKEET_MODEL", "nemo-parakeet-tdt-0.6b-v3")
+# Empty string means fp32; see the build arg of the same name in the Dockerfile.
+QUANTIZATION = os.environ.get("PARAKEET_QUANTIZATION", "int8") or None
+# Matches the cpuset in compose.yaml. Left to onnxruntime it would size the pool
+# from the host's core count and oversubscribe the cgroup.
+THREADS = int(os.environ.get("PARAKEET_THREADS", "3"))
+SAMPLE_RATE = 16000
+# A long upload is transcribed in windows rather than in one pass. This ONNX
+# export degrades sharply past ~30s of audio in a single call - it stops
+# transcribing part of it. Measured against 57s of continuous French, one
+# speaker, with a known reference of 163 words:
+#
+#   window   words returned   WER
+#     10s        157          20.2%
+#     20s        162          15.3%
+#     30s        160          16.6%
+#     60s         75          73.0%   <- half the audio simply missing
+#
+# 20s sits at the bottom of that curve with margin before the cliff, and keeps
+# the encoder's working set near 1.3GB; a single 120s pass took the container
+# past 2GB and the kernel killed it. A dictated sentence is one window and
+# reaches none of this.
+CHUNK_SECONDS = int(os.environ.get("PARAKEET_CHUNK_SECONDS", "20"))
+# How far either side of a window boundary to hunt for a quiet frame to cut on.
+# Cutting mid-word costs the word, and worse, leaves the next window opening on
+# half a syllable: Parakeet picks its language acoustically, and a window that
+# starts without context is the one that comes back in English ("It has de
+# nombreuses repercussions"). Aligning the cut to a pause is a few lines of
+# numpy here rather than a second model to load and feed, and on 113s of French
+# spliced to cut badly on purpose it took the transcript from 33.7% WER to 19.5%.
+CHUNK_SEARCH_SECONDS = float(os.environ.get("PARAKEET_CHUNK_SEARCH_SECONDS", "2.5"))
+# open-webui splits anything over 25MB itself before it gets here.
+MAX_UPLOAD_BYTES = int(os.environ.get("PARAKEET_MAX_UPLOAD_BYTES", str(64 * 1024 * 1024)))
+
+_model = None
+_infer_lock = threading.Lock()
+
+
+def load_model():
+    """Load once, at startup, and keep resident.
+
+    Deliberately not lazy: it costs ~5s, and paying that on the first press of
+    the microphone button reads as the feature being broken. Uvicorn does not
+    accept connections until this returns, so the container's healthcheck is
+    also its readiness signal.
+    """
+    opts = ort.SessionOptions()
+    opts.intra_op_num_threads = THREADS
+    opts.inter_op_num_threads = 1
+    log.info("loading %s (quantization=%s, threads=%d)", MODEL_NAME, QUANTIZATION or "fp32", THREADS)
+    model = onnx_asr.load_model(MODEL_NAME, quantization=QUANTIZATION, sess_options=opts)
+    log.info("model ready")
+    return model
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    global _model
+    _model = load_model()
+    yield
+
+
+app = FastAPI(title="Parakeet OpenAI-compatible STT", lifespan=lifespan)
+
+
+def decode_audio(raw: bytes) -> np.ndarray:
+    """Any container ffmpeg knows -> mono 16kHz float32, which is all onnx-asr takes."""
+    try:
+        proc = subprocess.run(
+            ["ffmpeg", "-hide_banner", "-loglevel", "error", "-i", "pipe:0",
+             "-f", "s16le", "-ac", "1", "-ar", str(SAMPLE_RATE), "pipe:1"],
+            input=raw, capture_output=True, timeout=300,
+        )
+    except subprocess.TimeoutExpired:
+        raise HTTPException(status_code=400, detail="Audio decoding timed out")
+
+    if proc.returncode != 0:
+        detail = proc.stderr.decode("utf-8", "replace").strip().splitlines()
+        raise HTTPException(status_code=400, detail=f"Could not decode audio: {detail[-1] if detail else 'ffmpeg failed'}")
+
+    samples = np.frombuffer(proc.stdout, dtype=np.int16)
+    if samples.size == 0:
+        raise HTTPException(status_code=400, detail="Audio contains no samples")
+    return samples.astype(np.float32) / 32768.0
+
+
+def split_on_pauses(waveform: np.ndarray) -> list[np.ndarray]:
+    """Cut into ~CHUNK_SECONDS windows, each boundary nudged to the nearest pause."""
+    window = CHUNK_SECONDS * SAMPLE_RATE
+    if waveform.size <= window:
+        return [waveform]
+
+    search = int(CHUNK_SEARCH_SECONDS * SAMPLE_RATE)
+    frame = SAMPLE_RATE // 20  # 50ms, short enough to land inside a pause between words
+
+    # Energy per frame, once for the whole clip: the boundary search is then a
+    # slice and an argmin rather than a pass over the samples each time.
+    usable = waveform.size - (waveform.size % frame)
+    energy = np.abs(waveform[:usable].reshape(-1, frame)).mean(axis=1)
+
+    chunks, start = [], 0
+    while waveform.size - start > window:
+        target = start + window
+        lo = max(start + frame, target - search) // frame
+        hi = min(waveform.size - frame, target + search) // frame
+        cut = (lo + int(np.argmin(energy[lo:hi]))) * frame if hi > lo else target
+        chunks.append(waveform[start:cut])
+        start = cut
+    chunks.append(waveform[start:])
+    return chunks
+
+
+def transcribe(waveform: np.ndarray) -> str:
+    chunks = split_on_pauses(waveform)
+    with _infer_lock:
+        parts = [_model.recognize(c, sample_rate=SAMPLE_RATE) for c in chunks]
+    return " ".join(p.strip() for p in parts if p and p.strip())
+
+
+# Deliberately `def` and not `async def`: ffmpeg and the inference loop below are
+# both blocking, and on the event loop they would hold it for the whole call -
+# ~19s for a 113s recording - which is longer than the healthcheck's timeout, so
+# the container would report itself unhealthy for dictating a long note. A plain
+# def runs in Starlette's threadpool instead, leaving /health answerable and
+# letting concurrent uploads queue on _infer_lock, which is where they belong.
+@app.post("/v1/audio/transcriptions")
+def transcriptions(
+    file: UploadFile = File(...),
+    model: str | None = Form(None),
+    language: str | None = Form(None),
+) -> JSONResponse:
+    raw = file.file.read()
+    if not raw:
+        raise HTTPException(status_code=400, detail="Empty upload")
+    if len(raw) > MAX_UPLOAD_BYTES:
+        raise HTTPException(status_code=413, detail="Audio file too large")
+
+    waveform = decode_audio(raw)
+    seconds = waveform.size / SAMPLE_RATE
+    text = transcribe(waveform)
+    log.info("transcribed %s (%.1fs) -> %d chars", file.filename, seconds, len(text))
+    return JSONResponse({"text": text})
+
+
+@app.get("/health")
+def health() -> JSONResponse:
+    if _model is None:
+        raise HTTPException(status_code=503, detail="Model not loaded")
+    return JSONResponse({"status": "ok", "model": MODEL_NAME, "quantization": QUANTIZATION or "fp32"})

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -339,6 +339,92 @@ voice per user in **Settings → Audio**; it overrides the default. To add voice
 with `docker compose build piper`. To go back to the browser's own voices, set
 the TTS engine to Web API in Admin Settings - nothing re-imposes Piper.
 
+**Speech-to-text.** The microphone button goes through `parakeet`, built
+from `config/parakeet/` on top of NVIDIA's
+[Parakeet TDT 0.6B v3](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3), run
+as ONNX via [onnx-asr](https://github.com/istupakov/onnx-asr). As with Piper,
+upstream publishes no image - and onnx-asr has no HTTP server at all - so the
+image adds `config/parakeet/openai_api.py`, an OpenAI-compatible facade serving
+`POST /v1/audio/transcriptions`, the shape Open WebUI's "OpenAI" STT engine
+calls. The weights are baked into the image, so the container needs no network.
+
+It is wired on both paths, and needs nothing done by hand on either. A fresh
+install is configured by the `AUDIO_STT_*` variables on the open-webui service:
+those are PersistentConfig, read into the database on an instance's very first
+start, so `make install` comes up dictating with no second step. An instance
+whose database already exists ignores them by design, and there
+`scripts/open-webui-bootstrap.sh` writes the same values once (marker
+`pi-pcloud.local_stt_defaults`). The image itself is built by the `docker compose
+up -d` the systemd unit already runs, so the first boot after a checkout builds
+it and starts it like any other service. The setting is global rather than
+per-account, and the microphone is on for every role by default
+(`chat.stt` in `user.permissions`), so it works for every user the moment they
+sign in - no admin approval, no per-user configuration.
+
+Open WebUI ships its own faster-whisper, and that is what this replaces. It runs
+*inside* the open-webui container, which is capped at 1g and already sits near
+730MB, so the only model that fits is the default `base` - and `base` is the
+reason dictated French comes back wrong. Measured on 113 seconds of read French
+([FLEURS](https://huggingface.co/datasets/google/fleurs) `fr_fr`) across this
+Pi's three AI cores:
+
+| Engine | WER | Speed | Resident |
+|--------|-----|-------|----------|
+| faster-whisper `base` (Open WebUI's default) | 20.2% | 0.95x realtime | ~630MB |
+| faster-whisper `small` | 12.5% | 1.25x realtime | ~1.0GB |
+| faster-whisper `medium` | 4.9% | 3.99x realtime | ~2.7GB |
+| **Parakeet TDT v3, int8 (in use)** | **8.7%** | **0.17x realtime** | **~1.2GB** |
+| Parakeet TDT v3, fp32 | 4.5% | 0.30x realtime | ~2.3GB |
+
+Whisper decodes autoregressively - a token at a time, so accuracy is bought with
+wall-clock. Parakeet is a TDT model whose decoder is a small joint network
+stepped once per frame, which is why it reaches whisper-`medium` accuracy at a
+twentieth of the cost. In practice a dictated sentence comes back in well under
+a second, and it punctuates and capitalises.
+
+**It has no language setting at all**, and that is the other half of the fix.
+Parakeet was trained on 25 European languages and picks one acoustically, so
+dictating in English tomorrow needs no switch flipped - where whisper
+*auto-detects*, and its failure mode on a short French clip is to decide the
+audio is English and transliterate it. Open WebUI still sends a `language`
+field; the facade accepts and ignores it. The measurements here were taken on
+French because that is what gets dictated on this box, not because anything
+restricts it to French.
+
+For **more accuracy at twice the memory**, rebuild in fp32 - 4.5% WER, still
+three times faster than realtime, but ~2.3GB resident and a ~2.5GB model in the
+image:
+
+```bash
+docker compose build --build-arg PARAKEET_QUANTIZATION= parakeet
+```
+
+and set `PARAKEET_QUANTIZATION=` (empty) on the service in `compose.yaml`, so
+the weights loaded are the weights baked in. Raise `mem_limit` to `3584m` too.
+
+Long uploads are transcribed in 20-second windows. That is not only about
+memory - a single 120-second pass took the container past 2GB and got it killed -
+but about a cliff in the ONNX export, which stops transcribing part of a long
+call. Against 57 seconds of continuous French with a 163-word reference:
+
+| Window | Words returned | WER |
+|--------|----------------|-----|
+| 10s | 157 | 20.2% |
+| **20s** | **162** | **15.3%** |
+| 30s | 160 | 16.6% |
+| 60s | 75 | 73.0% |
+
+At 60 seconds half the audio simply goes missing, so the window has to stay well
+under it. Boundaries are then nudged onto the quietest nearby frame rather than
+falling wherever 20 seconds lands, because a window that opens mid-word is the
+one that comes back in the wrong language - on a deliberately badly-cut sample
+that alone took the transcript from 33.7% WER to 19.5%. Dictation reaches none of
+this: it is one window. Tune with `PARAKEET_CHUNK_SECONDS` if you feed it long
+recordings.
+
+To go back to Open WebUI's built-in whisper, set the STT engine to Whisper
+(Local) in **Admin Settings → Audio** - nothing re-imposes Parakeet.
+
 **Changing the model.** Edit the `DOWNLOADS` list in
 `config/llama-cpp/fetch-models.sh`, then point `LLAMA_ARG_MODEL` (and
 `LLAMA_ARG_MMPROJ` / `LLAMA_ARG_SPEC_DRAFT_MODEL`, or drop them) at the new

--- a/scripts/open-webui-bootstrap.sh
+++ b/scripts/open-webui-bootstrap.sh
@@ -53,6 +53,16 @@ case "$DEFAULT_LANGUAGE" in
     # silently substituted on every request.
     *)   TTS_VOICE="en_US-lessac-medium" ;;
 esac
+# Speech-to-text, its own marker again so the two audio halves move separately.
+# No language in the version: parakeet-tdt-0.6b-v3 is multilingual and picks the
+# language off the audio, so DEFAULT_LANGUAGE has nothing to select here.
+STT_MARKER="pi-pcloud.local_stt_defaults"
+STT_VERSION='"1"'
+# Parakeet's OpenAI-compatible facade (config/parakeet), on the ai network.
+STT_BASE_URL="http://parakeet:8000/v1"
+# Sent as the `model` field and otherwise ignored: the container serves the one
+# model it was built with. Set so the admin page names something recognisable.
+STT_MODEL="parakeet-tdt-0.6b-v3"
 # The interface language. DEFAULT_LOCALE is PersistentConfig like the rest, so
 # compose only reaches an instance that has never started; here the database
 # still holds Open WebUI's own empty default, which means "follow the browser".
@@ -164,6 +174,34 @@ ON CONFLICT (key) DO UPDATE
 SQL
 }
 
+# Point the microphone button at the local Parakeet container. This mirrors the
+# AUDIO_STT_* variables on the open-webui service, which cover a fresh install on
+# their own - those are PersistentConfig, so they are ignored by an instance
+# whose database already exists, which is the case this function is here for.
+#
+# Seeded, not enforced, like the TTS block above: an engine has to be named for the feature
+# to work at all, but this runs once, so switching back to Open WebUI's built-in
+# whisper - or out to a hosted API - in Admin Settings > Audio sticks.
+#
+# Leaving the engine empty is what selects that built-in whisper, which runs
+# inside the open-webui container: `base`, 20.2% WER on read French, and no room
+# under that container's 1g to load anything better. See the parakeet service in
+# compose.yaml for the numbers behind the swap.
+#
+# No API key: the ai network is internal and the facade authenticates nobody,
+# same as llama-cpp and piper.
+apply_stt_defaults() {
+    psql_owui -q <<SQL
+INSERT INTO config (key, value, updated_at) VALUES
+    ('audio.stt.engine',              '"openai"'::json,        extract(epoch from now())::bigint),
+    ('audio.stt.openai.api_base_url', '"$STT_BASE_URL"'::json, extract(epoch from now())::bigint),
+    ('audio.stt.model',               '"$STT_MODEL"'::json,    extract(epoch from now())::bigint),
+    ('$STT_MARKER',                   '$STT_VERSION'::json,    extract(epoch from now())::bigint)
+ON CONFLICT (key) DO UPDATE
+    SET value = EXCLUDED.value, updated_at = EXCLUDED.updated_at;
+SQL
+}
+
 # Open WebUI fires an extra, invisible LLM call per message for each of these:
 # a chat title, chat tags, follow-up suggestions, a search query rewrite. Against
 # a cloud API that is free; against a Pi generating ~10 tok/s it multiplies the
@@ -266,6 +304,15 @@ main() {
             changed=1
         else
             log "WARNING: failed to seed Open WebUI text-to-speech settings"
+        fi
+    fi
+
+    if [ "$(marker_present "$STT_MARKER" "$STT_VERSION")" = "f" ]; then
+        log "Pointing speech-to-text at Parakeet ($STT_MODEL)"
+        if apply_stt_defaults; then
+            changed=1
+        else
+            log "WARNING: failed to seed Open WebUI speech-to-text settings"
         fi
     fi
 


### PR DESCRIPTION
## Why

Open WebUI ships its own faster-whisper, but it runs **inside** the open-webui container — capped at 1g and already sitting near 730MB — so the only model that fits is the default `base`, and `base` is why dictated French came back wrong.

Measured on 113s of read French ([FLEURS](https://huggingface.co/datasets/google/fleurs) `fr_fr`) across this Pi's three AI cores:

| Engine | WER | Speed | Resident |
|--------|-----|-------|----------|
| faster-whisper `base` (Open WebUI's default) | 20.2% | 0.95x realtime | ~630MB |
| faster-whisper `small` | 12.5% | 1.25x realtime | ~1.0GB |
| faster-whisper `medium` | 4.9% | 3.99x realtime | ~2.7GB |
| **Parakeet TDT v3, int8 (this PR)** | **8.7%** | **0.17x realtime** | **~1.2GB** |
| Parakeet TDT v3, fp32 | 4.5% | 0.30x realtime | ~2.3GB |

Whisper decodes autoregressively — a token at a time, so accuracy is bought with wall-clock. Parakeet is a TDT model whose decoder is a small joint network stepped once per frame, which is how it reaches whisper-`medium` accuracy at a twentieth of the cost. A dictated sentence comes back in well under a second, punctuated and capitalised.

**It also has no language setting at all.** Trained on 25 European languages and picking one acoustically, where whisper *auto-detects* and its failure mode on a short French clip is to decide the audio is English and transliterate it. The numbers above are French because that is what gets dictated here, not because anything restricts it.

## How

Upstream publishes no image and `onnx-asr` has no HTTP server, so `config/parakeet/` adds an OpenAI-compatible facade serving `POST /v1/audio/transcriptions` — the shape Open WebUI's "OpenAI" STT engine calls. Weights are baked in, so the container needs no network.

Long uploads are transcribed in 20-second windows. Not only for memory (a single 120s pass took the container past 2GB and got it killed) but because the ONNX export drops audio past ~60s — 75 of 163 words returned, 73% WER. Boundaries are nudged onto the quietest nearby frame, because a window opening mid-word is the one that comes back in the wrong language (33.7% → 19.5% WER on a deliberately badly-cut sample). Dictation never reaches any of this: it is one window.

Wired on both paths so neither install needs a manual step:

- `AUDIO_STT_*` on the open-webui service covers a fresh database (PersistentConfig, read on first start).
- `scripts/open-webui-bootstrap.sh` seeds the same values once (marker `pi-pcloud.local_stt_defaults`) for an instance whose database already exists and therefore ignores them.

Switching back to the built-in whisper in **Admin Settings → Audio** sticks — nothing re-imposes Parakeet.

Touches `compose.yaml` and `scripts/open-webui-bootstrap.sh` alongside #209 and #211 — expect small merge conflicts depending on order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)