### PR TITLE
feat(ai): let the local model answer questions about this server

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you're deciding between approaches, here's the short version:
 | **Network & Security** | Traefik (reverse proxy), Tailscale/Headscale (VPN), Authelia (SSO), LLDAP (user directory) |
 | **DNS & Filtering** | Pi-hole (ad-blocking), Unbound (recursive DNS) |
 | **Download** | qBittorrent (torrent client), Prowlarr (indexer manager), Kapowarr (comics manager), FlareSolverr (Cloudflare solver), Gluetun (VPN kill-switch gateway) |
-| **AI** | Open WebUI (chat interface), llama.cpp (local Gemma 4 E2B inference, CPU-only), Piper (text-to-speech, French voices), Parakeet (multilingual speech-to-text) |
+| **AI** | Open WebUI (chat interface), llama.cpp (local Gemma 4 E2B inference, CPU-only), Piper (text-to-speech, French voices), Parakeet (multilingual speech-to-text), system status tools |
 | **Monitoring & Backup** | Beszel (monitoring), Backrest (restic backups), Dockhand (container management) |
 | **Infrastructure** | PostgreSQL, Redis, ddns-updater |
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1757,6 +1757,72 @@ services:
     # measured). The headroom is what stops a long upload from being an OOM:
     # before openai_api.py windowed them, a 120s pass went past 2GB.
     mem_limit: 2560m
+
+  # Serves the host's status to the local model as an OpenAPI tool; see
+  # config/system-tools/app.py. / is mounted at /hostfs because statvfs cannot
+  # measure a filesystem this process cannot see.
+  system-tools:
+    <<: *service-defaults
+    build:
+      context: ./config/system-tools
+      dockerfile: Dockerfile
+    image: pi-system-tools:local
+    container_name: pi-system-tools
+    networks:
+      - ai
+      # `devices` reads headscale's node API, which only listens on frontend.
+      # Egress only: nothing here accepts a URL, so the reachable surface widens
+      # but the steerable one does not. Putting headscale on `ai` instead would
+      # hand it a leg into the network where open-webui runs admin-supplied Python.
+      - frontend
+    expose:
+      - 8000
+    environment:
+      # Without this the container is UTC and `uptime` is four hours off.
+      - TZ=${TIMEZONE:-Europe/Paris}
+      # Derived from the directory name, so it cannot be guessed in-container.
+      - COMPOSE_PROJECT=${COMPOSE_PROJECT_NAME:-pi-web}
+      # Backrest's own log, because the repos are remote and restic would want
+      # their password. Read off the bind mount below rather than through
+      # /hostfs: DATA_LOCATION is relative to the project directory by default,
+      # and a relative path means nothing against the host root.
+      - BACKREST_OPLOG=/run/backrest/oplog.sqlite
+      - HEADSCALE_URL=http://pi-headscale:8080
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    volumes:
+      # rslave, or unplugging /mnt/usbdrive fails while this container runs.
+      - type: bind
+        source: /
+        target: /hostfs
+        read_only: true
+        bind:
+          propagation: rslave
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      # Backrest's data directory, holding the oplog `backups` reads. A directory
+      # rather than the file itself: the oplog does not exist before backrest's
+      # first run, and Docker would materialise a directory in its place.
+      - ${DATA_LOCATION:-./data}/backrest/data:/run/backrest:ro
+      # The key homepage's headscale widget already uses, rather than a second one
+      # to rotate. Headscale API keys expire, so both break together.
+      # scripts/headscale-pre-start.sh keeps the path a file; without it Docker
+      # would create a directory here on a fresh install, and the bootstrap that
+      # fills the key in could then never write it.
+      - ./config/homepage/secrets/headscale_api_key:/run/secrets/headscale_api_key:ro
+    healthcheck:
+      <<: *healthcheck-relaxed
+      # python:3.12-slim ships no curl or wget.
+      test: ["CMD", "python3", "-c", "import urllib.request as r; r.urlopen('http://localhost:8000/health').read()"]
+      start_period: 20s
+    labels:
+      - "homepage.group=AI"
+      - "homepage.name=System Tools"
+      - "homepage.description=Server status for the local LLM"
+      - "homepage.icon=mdi-tools"
+    # No cpuset: a call only runs while llama-cpp waits for its result.
+    deploy: *cpu-request-tiny
+    mem_limit: 192m
     oom_score_adj: *oom-score-deprioritize
 
   open-webui:
@@ -1776,6 +1842,9 @@ services:
       - ENABLE_LOGIN_FORM=false
       - CORS_ALLOW_ORIGIN=https://ai.${HOST_NAME:-pi.lan}
       - ENABLE_OAUTH_SIGNUP=true
+      # Authelia already gates ai.${HOST_NAME:-pi.lan}, so Open WebUI's own
+      # "pending" default would just park every SSO login until an admin looks.
+      - DEFAULT_USER_ROLE=user
       - OAUTH_CLIENT_ID=open-webui
       - OPENID_PROVIDER_URL=https://auth.${HOST_NAME:-pi.lan}/.well-known/openid-configuration
       - OAUTH_PROVIDER_NAME=Authelia
@@ -1816,6 +1885,12 @@ services:
       postgres:
         condition: service_healthy
       llama-cpp:
+        condition: service_started
+      # service_started, not service_healthy: system-tools is on the relaxed
+      # healthcheck (120s interval, no start_interval), so Docker's first probe
+      # lands at t=120s and the chat UI would wait for it on every boot - for a
+      # tool server that is only ever called mid-conversation.
+      system-tools:
         condition: service_started
     healthcheck:
       <<: *healthcheck-relaxed

--- a/config/system-tools/Dockerfile
+++ b/config/system-tools/Dockerfile
@@ -1,0 +1,17 @@
+# Built rather than pulled: every off-the-shelf equivalent (node-exporter,
+# glances) speaks Prometheus or its own JSON, not the OpenAPI shape Open WebUI
+# discovers tools from.
+FROM python:3.12-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    HOSTFS=/hostfs
+
+RUN pip install --no-cache-dir \
+        "fastapi>=0.115,<1" \
+        "uvicorn>=0.34,<1"
+
+COPY app.py /app/app.py
+WORKDIR /app
+
+EXPOSE 8000
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "1"]

--- a/config/system-tools/app.py
+++ b/config/system-tools/app.py
@@ -1,0 +1,466 @@
+"""Read-only system status, as an OpenAPI tool server for Open WebUI.
+
+Open WebUI injects every operation of the spec into the prompt of every message,
+and this Pi processes prompts at ~40 tok/s - so the schema is a latency budget,
+and so are the replies, which are re-processed on the next turn. One operation
+with an enum costs 170 tokens, about +14 per topic added, where one extra
+operation costs +72 on its own. `df -h` alone would cost ~400 in padding.
+
+/proc and /sys are host-wide inside a container already; statvfs is not, which is
+the only reason / is bind-mounted at /hostfs.
+
+No endpoint takes a command, a path or a pattern, so an injected prompt has
+nothing to steer.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import sqlite3
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+from fastapi import FastAPI
+from fastapi.responses import PlainTextResponse
+
+HOSTFS = Path(os.environ.get("HOSTFS", "/hostfs"))
+PROC = HOSTFS / "proc"
+SYS = HOSTFS / "sys"
+DOCKER_SOCK = os.environ.get("DOCKER_SOCK", "/var/run/docker.sock")
+# The socket is the host's: unfiltered, the list covers containers that have
+# nothing to do with this stack, and a stray Exited one reads as a fault.
+COMPOSE_PROJECT = os.environ.get("COMPOSE_PROJECT", "pi-web")
+# Backrest's data directory is bind-mounted straight in (see compose.yaml); this
+# is not a host path resolved under HOSTFS, because DATA_LOCATION is relative to
+# the project directory by default and would land somewhere else entirely.
+OPLOG = Path(os.environ.get("BACKREST_OPLOG", "/run/backrest/oplog.sqlite"))
+
+# From backrest's proto/v1/operations.proto. WARNING is declared before ERROR but
+# numbered after the cancellations, so reading declaration order off the binary
+# gets these backwards.
+BACKUP_STATUS = {
+    0: "state unknown",
+    1: "scheduled",
+    2: "running",
+    3: "succeeded",
+    4: "FAILED",
+    5: "cancelled by the system",
+    6: "cancelled",
+    7: "succeeded with warnings",
+}
+FINISHED = (3, 4, 7)
+
+# A container started this recently is worth mentioning even with no restart
+# counted against it, because `docker compose up` resets the counter.
+RECENT_START = 3600
+LOG_LINES = 3
+LOG_WIDTH = 120
+
+HEADSCALE_URL = os.environ.get("HEADSCALE_URL", "")
+HEADSCALE_KEY_FILE = Path(os.environ.get("HEADSCALE_KEY_FILE", "/run/secrets/headscale_api_key"))
+# All of them fit in a digest at this size; past it, offline devices are trimmed
+# oldest-first and the reply says how many it dropped.
+DEVICE_LINES = 25
+
+# Named rather than discovered: enumerating the host's mount table meant
+# filtering two dozen pseudo-filesystems and container layers down to these.
+# topic_overview reports the first line, so `/` stays first.
+FILESYSTEMS = ("/", "/mnt/usbdrive", "/mnt/sdcard")
+
+app = FastAPI(
+    title="Pi system status",
+    description="Read-only status of the server this assistant runs on.",
+    version="1.0.0",
+)
+
+
+def read(path: Path, default: str = "") -> str:
+    try:
+        return path.read_text()
+    except OSError:
+        return default
+
+
+def human_bytes(num: float) -> str:
+    for unit in ("B", "K", "M", "G", "T"):
+        if abs(num) < 1024 or unit == "T":
+            return f"{num:.0f}{unit}" if unit in ("B", "K") else f"{num:.1f}{unit}"
+        num /= 1024
+    return f"{num:.1f}T"
+
+
+def duration(seconds: float) -> str:
+    days, rem = divmod(int(seconds), 86400)
+    hours, rem = divmod(rem, 3600)
+    minutes = rem // 60
+    parts = []
+    if days:
+        parts.append(f"{days}d")
+    if hours or days:
+        parts.append(f"{hours}h")
+    parts.append(f"{minutes}m")
+    return " ".join(parts)
+
+
+def topic_disk() -> str:
+    lines = []
+    for mount in FILESYSTEMS:
+        path = HOSTFS / mount.lstrip("/")
+        # An unmounted drive leaves an empty directory on the root filesystem,
+        # for which statvfs answers with the root filesystem's own numbers.
+        if not path.is_mount():
+            continue
+        try:
+            st = os.statvfs(path)
+        except OSError:
+            continue
+        total = st.f_blocks * st.f_frsize
+        if not total:
+            continue
+        free = st.f_bavail * st.f_frsize
+        used = total - st.f_bfree * st.f_frsize
+        lines.append(f"{mount}: {human_bytes(free)} free of {human_bytes(total)} ({used * 100 // total}% used)")
+    return "\n".join(lines) or "no filesystem readable"
+
+
+def cpu_times() -> list[list[int]]:
+    rows = []
+    for entry in read(PROC / "stat").splitlines():
+        if not entry.startswith("cpu"):
+            break
+        rows.append([int(v) for v in entry.split()[1:]])
+    return rows
+
+
+def topic_cpu() -> str:
+    # Two samples 300ms apart: /proc/stat is cumulative since boot, so a single
+    # read would report the average since power-on rather than "right now".
+    first = cpu_times()
+    time.sleep(0.3)
+    second = cpu_times()
+    if not first or not second:
+        return "cpu unreadable"
+
+    def busy(before: list[int], after: list[int]) -> float:
+        total = sum(after) - sum(before)
+        idle = (after[3] + after[4]) - (before[3] + before[4])
+        return 100.0 * (total - idle) / total if total > 0 else 0.0
+
+    cores = len(first) - 1
+    lines = [f"usage: {busy(first[0], second[0]):.0f}% over {cores} cores"]
+    per_core = ", ".join(f"{busy(first[i], second[i]):.0f}%" for i in range(1, len(first)))
+    lines.append(f"per core: {per_core}")
+
+    load = read(PROC / "loadavg").split()
+    if len(load) >= 3:
+        lines.append(f"load average: {load[0]} {load[1]} {load[2]} (1/5/15 min, saturated above {cores})")
+
+    temp = read(SYS / "class/thermal/thermal_zone0/temp").strip()
+    if temp.isdigit():
+        lines.append(f"temperature: {int(temp) / 1000:.1f}C")
+
+    freqs = sorted(SYS.glob("devices/system/cpu/cpu[0-9]*/cpufreq/scaling_cur_freq"))
+    values = [int(read(f).strip() or 0) for f in freqs]
+    if any(values):
+        lines.append(f"clock: {max(values) // 1000} MHz")
+
+    return "\n".join(lines)
+
+
+def topic_memory() -> str:
+    info = {}
+    for entry in read(PROC / "meminfo").splitlines():
+        key, _, value = entry.partition(":")
+        info[key] = int(value.split()[0]) * 1024 if value.split() else 0
+    total, available = info.get("MemTotal", 0), info.get("MemAvailable", 0)
+    if not total:
+        return "memory unreadable"
+    lines = [f"RAM: {human_bytes(available)} available of {human_bytes(total)} ({(total - available) * 100 // total}% used)"]
+    swap_total, swap_free = info.get("SwapTotal", 0), info.get("SwapFree", 0)
+    if swap_total:
+        lines.append(f"swap: {human_bytes(swap_total - swap_free)} used of {human_bytes(swap_total)}")
+    return "\n".join(lines)
+
+
+def topic_uptime() -> str:
+    # split() rather than `or "0"`: a whitespace-only read is truthy.
+    fields = read(PROC / "uptime").split()
+    if not fields:
+        return "uptime unreadable"
+    up = float(fields[0])
+    booted = time.strftime("%Y-%m-%d %H:%M", time.localtime(time.time() - up))
+    return f"up {duration(up)} (booted {booted})\nhost time: {time.strftime('%Y-%m-%d %H:%M %Z')}"
+
+
+def docker_raw(path: str) -> bytes:
+    """No client library: this is a GET over a unix socket."""
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+            sock.settimeout(5)
+            sock.connect(DOCKER_SOCK)
+            sock.sendall(f"GET {path} HTTP/1.0\r\nHost: docker\r\n\r\n".encode())
+            chunks = []
+            while data := sock.recv(65536):
+                chunks.append(data)
+        return b"".join(chunks).split(b"\r\n\r\n", 1)[1]
+    except (OSError, IndexError):
+        return b""
+
+
+def docker_get(path: str) -> object | None:
+    try:
+        return json.loads(docker_raw(path))
+    except ValueError:
+        return None
+
+
+def project_containers() -> list[dict]:
+    query = quote(json.dumps({"label": [f"com.docker.compose.project={COMPOSE_PROJECT}"]}))
+    containers = docker_get(f"/containers/json?all=1&filters={query}")
+    return containers if isinstance(containers, list) else []
+
+
+def short_name(container: dict) -> str:
+    return (container.get("Names") or ["?"])[0].lstrip("/").removeprefix("pi-")
+
+
+def rfc3339(value: str) -> float | None:
+    """Docker and headscale both carry nanoseconds, which %f cannot read; an event
+    that never happened is reported as year 0001."""
+    if not value or value.startswith("0001"):
+        return None
+    try:
+        stamp = datetime.strptime(value.partition(".")[0], "%Y-%m-%dT%H:%M:%S")
+    except ValueError:
+        return None
+    return stamp.replace(tzinfo=timezone.utc).timestamp()
+
+
+def topic_services() -> str:
+    containers = project_containers()
+    if not containers:
+        return "container list unavailable"
+    healthy, degraded = [], []
+    for container in containers:
+        name = short_name(container)
+        status = container.get("Status", "")
+        state = container.get("State", "")
+        if state == "running" and "unhealthy" not in status:
+            healthy.append(name)
+        else:
+            degraded.append(f"{name} ({status or state})")
+    lines = [f"{len(healthy)} of {len(containers)} containers running and healthy"]
+    if degraded:
+        lines.append("needs attention: " + ", ".join(sorted(degraded)))
+    else:
+        lines.append("nothing needs attention")
+    return "\n".join(lines)
+
+
+def topic_restarts() -> str:
+    lines = []
+    now = time.time()
+    for container in project_containers():
+        detail = docker_get(f"/containers/{container['Id']}/json")
+        if not isinstance(detail, dict):
+            continue
+        state = detail.get("State") or {}
+        count = detail.get("RestartCount") or 0
+        started = rfc3339(state.get("StartedAt", ""))
+        age = now - started if started else None
+        if count:
+            note = f"{short_name(container)}: {count} restart{'s' if count > 1 else ''}"
+            stopped = rfc3339(state.get("FinishedAt", ""))
+            if stopped:
+                note += f", last exit code {state.get('ExitCode')} {duration(now - stopped)} ago"
+            lines.append((age if age is not None else 0.0, note))
+        elif age is not None and age < RECENT_START:
+            lines.append((age, f"{short_name(container)}: started {duration(age)} ago"))
+    if not lines:
+        return "no container has restarted"
+    lines.sort()
+    return "\n".join(note for _, note in lines[:6])
+
+
+def failing_containers() -> list[dict]:
+    return [
+        container
+        for container in project_containers()
+        if container.get("State") != "running" or "unhealthy" in container.get("Status", "")
+    ]
+
+
+def log_lines(body: bytes) -> list[str]:
+    """Docker prefixes every chunk with an 8-byte frame header, unless the
+    container was given a TTY, in which case the stream is verbatim."""
+    chunks, offset = [], 0
+    while offset + 8 <= len(body):
+        if body[offset] not in (0, 1, 2) or body[offset + 1 : offset + 4] != b"\x00\x00\x00":
+            break
+        size = int.from_bytes(body[offset + 4 : offset + 8], "big")
+        chunks.append(body[offset + 8 : offset + 8 + size])
+        offset += 8 + size
+    if not chunks:
+        chunks = [body]
+    text = b"".join(chunks).decode("utf-8", "replace")
+    return [line.strip() for line in text.splitlines() if line.strip()]
+
+
+def topic_errors() -> str:
+    failing = failing_containers()
+    if not failing:
+        return "no container is failing, so there is nothing to quote"
+    blocks = []
+    # Only containers already known to be broken, and only their tail: the model
+    # never names what gets read, and a reply is prompt tokens on every later turn.
+    for container in failing[:3]:
+        lines = log_lines(
+            docker_raw(f"/containers/{container['Id']}/logs?stderr=1&stdout=1&tail={LOG_LINES}")
+        )[-LOG_LINES:]
+        header = f"{short_name(container)} ({container.get('Status') or container.get('State')}):"
+        body = "\n".join(f"  {line[:LOG_WIDTH]}" for line in lines) or "  (no output)"
+        blocks.append(f"{header}\n{body}")
+    if len(failing) > 3:
+        blocks.append(f"({len(failing) - 3} more failing, not quoted)")
+    return "\n".join(blocks)
+
+
+def topic_backups() -> str:
+    """Read from backrest's operation log rather than its API: the repos live on a
+    remote, and the log answers "did last night run" without a restic password."""
+    try:
+        with sqlite3.connect(f"file:{OPLOG}?mode=ro", uri=True) as log:
+            rows = log.execute(
+                "SELECT g.plan_id, g.repo_id, o.status, o.start_time_ms, o.snapshot_id "
+                "FROM operations o JOIN operation_groups g ON g.ogid = o.ogid "
+                "WHERE g.plan_id != '_system_' ORDER BY o.start_time_ms DESC"
+            ).fetchall()
+    except sqlite3.Error:
+        return "backup log unreadable"
+    if not rows:
+        return "no backup recorded"
+
+    now = time.time()
+    latest, scheduled, failures = {}, {}, {}
+    for plan, repo, status, start_ms, snapshot in rows:
+        key = f"{plan} -> {repo}"
+        when = start_ms / 1000
+        if status in FINISHED:
+            failures[key] = failures.get(key, 0) + (status == 4)
+            latest.setdefault(key, (when, status, snapshot))
+        elif status == 1 and when > now:
+            scheduled[key] = when
+
+    lines = []
+    for key, (when, status, snapshot) in latest.items():
+        line = f"{key}: {BACKUP_STATUS.get(status, status)} {duration(now - when)} ago"
+        if snapshot:
+            line += f" (snapshot {snapshot[:8]})"
+        if failures.get(key):
+            line += f", {failures[key]} failed run(s) on record"
+        if key in scheduled:
+            line += f"; next in {duration(scheduled[key] - now)}"
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def topic_devices() -> str:
+    """The tailnet is served by headscale (config/headscale), so this reads its
+    node API rather than tailscale's SaaS one. Every device is listed with when it
+    was last seen, which is what makes "when was X last online" answerable without
+    a parameter naming X - the model reads it off the list."""
+    if not HEADSCALE_URL:
+        return "tailnet not configured"
+    key = read(HEADSCALE_KEY_FILE).strip()
+    if not key:
+        return "tailnet key unavailable"
+    try:
+        request = Request(f"{HEADSCALE_URL}/api/v1/node", headers={"Authorization": f"Bearer {key}"})
+        with urlopen(request, timeout=5) as response:
+            nodes = json.load(response).get("nodes") or []
+    except (OSError, ValueError):
+        return "tailnet unreachable"
+    if not nodes:
+        return "no device registered"
+
+    now = time.time()
+    online, offline = [], []
+    for node in nodes:
+        label = node.get("givenName") or node.get("name") or "?"
+        owner = (node.get("user") or {}).get("name") or "?"
+        if node.get("online"):
+            online.append(f"online   {label} ({owner})")
+        else:
+            seen = rfc3339(node.get("lastSeen", ""))
+            when = f"last seen {duration(now - seen)} ago" if seen else "never seen"
+            offline.append((seen or 0.0, f"offline  {label} ({owner}), {when}"))
+
+    offline.sort(reverse=True)
+    users = sorted({(node.get("user") or {}).get("name") or "?" for node in nodes})
+    header = f"{len(online)} of {len(nodes)} devices online, {len(users)} users: {', '.join(users)}"
+    room = max(DEVICE_LINES - len(online), 0)
+    lines = [header] + online + [line for _, line in offline[:room]]
+    if len(offline) > room:
+        lines.append(f"({len(offline) - room} more offline, not listed)")
+    return "\n".join(lines)
+
+
+def topic_overview() -> str:
+    return "\n".join(
+        [
+            topic_uptime().splitlines()[0],
+            topic_cpu().splitlines()[0],
+            topic_memory().splitlines()[0],
+            topic_disk().splitlines()[0],
+            topic_services().splitlines()[0],
+        ]
+    )
+
+
+TOPICS = {
+    "overview": topic_overview,
+    "disk": topic_disk,
+    "cpu": topic_cpu,
+    "memory": topic_memory,
+    "uptime": topic_uptime,
+    "services": topic_services,
+    "restarts": topic_restarts,
+    "errors": topic_errors,
+    "backups": topic_backups,
+    "devices": topic_devices,
+}
+
+Topic = Literal[
+    "overview", "disk", "cpu", "memory", "uptime",
+    "services", "restarts", "errors", "backups", "devices",
+]
+
+
+@app.get(
+    "/status/{topic}",
+    operation_id="get_system_status",
+    summary="Live status of the server this assistant runs on",
+    description=(
+        "Returns current server measurements. Topics: overview (a summary of all of them), "
+        "disk (free space per filesystem), cpu (usage, load, temperature), memory (RAM and swap), "
+        "uptime, services (are the containers up), "
+        "restarts (what restarted and why), errors (log tail of whatever is failing), "
+        "backups (last backup and whether it worked), "
+        "devices (tailnet devices, who owns them, which are online and when the "
+        "offline ones were last seen). Call this instead of guessing."
+    ),
+    response_class=PlainTextResponse,
+)
+def get_system_status(topic: Topic) -> str:
+    return TOPICS[topic]()
+
+
+@app.get("/health", include_in_schema=False)
+def health() -> dict[str, str]:
+    return {"status": "ok"}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -288,12 +288,190 @@ connections the model simply never shows up in the picker.
 leaves any other connection you configured in the UI alone, and restarts
 open-webui only when it changed something. It also seeds the low-latency
 defaults above - once, guarded by a `pi-pcloud.local_ai_defaults` marker row, so
-anything you change afterwards in Admin Settings stays changed. Run it by hand
-after a database restore:
+anything you change afterwards in Admin Settings stays changed. The same script
+registers the `system-tools` server below (marker `pi-pcloud.system_tools`) and
+seeds the new-chat suggestions (marker `pi-pcloud.prompt_suggestions`); the
+markers are independent, so re-seeding one never re-imposes the others.
+
+Everything that writes the model's *workspace row* - turning the built-in tools
+off (marker `pi-pcloud.local_ai_model_defaults`), attaching the tool server,
+seeding the suggestions - needs an admin account to own that row, and there is
+none until the first SSO login. Those steps are therefore skipped, unmarked, on a
+fresh install, and applied by the next run of the hook; the settings that live in
+the `config` table alone (connection, low-latency defaults, audio) apply from
+the first boot. Run it by hand after the first login, or after a database
+restore:
 
 ```bash
 sh scripts/open-webui-bootstrap.sh
 ```
+
+**Who may use it.** Authelia already decides who reaches
+`ai.${HOST_NAME:-pi.lan}`, so Open WebUI's own `pending` role - which parks every
+SSO login behind an admin approval screen - would only mean nobody can use the
+service until an admin notices. The script sets `ui.default_user_role` to `user`
+and releases accounts already parked (marker `pi-pcloud.open_access`).
+
+That alone is not enough to make the assistant usable, because two separate
+things default to admin-only:
+
+- A model with a workspace row is kept by `get_filtered_models` only for its
+  owner or for someone named in an access grant. The row exists here to turn the
+  builtin tools off and it belongs to the admin, so every other account got an
+  **empty model picker**.
+- A tool server whose `config` carries no `access_grants` is private to admins
+  (`has_connection_access`), so a normal user clicking one of the suggestions
+  below would get an invented answer with no tool call.
+
+Both are granted wildcard public read - `('user', '*', 'read')`, the shape the
+code itself documents as public - by the same marker. They stay visible and
+revocable in **Admin Settings** and **Workspace → Models**; narrowing either one
+by hand is never undone. Admin rights still have to be granted deliberately.
+
+**Answering questions about this server.** `system-tools` (built from
+`config/system-tools/`) is an OpenAPI tool server on the `ai` network. Open WebUI
+discovers tools from an OpenAPI spec and hands them to the model as function
+definitions, so the model can measure the machine it runs on instead of guessing
+at it - "how much disk is left?", "is anything down?", "how long has it been
+up?". It is attached to `gemma-4-e2b-it` in the workspace, so it is live on every
+chat; untick it under the model in **Workspace → Models** to turn it off.
+
+One operation, `get_system_status(topic)`, with `topic` one of:
+
+| Topic | Answers with |
+|-------|--------------|
+| `overview` | One line each of uptime, CPU, RAM, `/`, containers |
+| `disk` | Free space on `/`, `/mnt/usbdrive` and `/mnt/sdcard` |
+| `cpu` | Usage overall and per core, load average, temperature, clock |
+| `memory` | RAM and swap |
+| `uptime` | Uptime, boot time, host clock |
+| `services` | Container count, and which ones are not running or not healthy |
+| `restarts` | What restarted, how often, and with which exit code |
+| `errors` | The last few log lines of whatever is currently failing |
+| `backups` | Last backup per plan, whether it worked, when the next one runs |
+| `devices` | Tailnet devices, their owner, which are online, when the rest were last seen |
+
+**Why one operation and not ten.** Tool schemas are injected into the prompt of
+every message. At ~40 tok/s of prompt processing they are the latency budget, and
+that is exactly why the built-in tools are off above - they cost ~5000 tokens,
+about three minutes before the model writes a word. This one is 170 tokens
+(`curl llama-cpp:8080/tokenize` on the payload Open WebUI builds from the spec),
+which llama-server then caches for the rest of the conversation.
+
+That shape is what keeps growth cheap, and the difference is measured: the enum has
+gone 6 → 10 topics for 113 → 170 tokens - about **+14 per topic**, depending on
+how much the topic's own description has to explain,
+where a single extra *operation* costs **+72** on its own. So a new capability
+becomes a topic, never a second operation.
+
+The replies are digested for the same reason, and it matters more than the schema
+does: a reply is re-processed on every later turn of the conversation. `df -h`
+alone is ~400 tokens of column padding, so nothing here returns raw command
+output, and `errors` caps itself at three containers and three lines each.
+
+**Topic selection is testable, so test it.** The real ceiling is not tokens, it is
+whether a 4B model still picks the right topic as the list grows. One prompt per
+topic, sent to `llama-server` with the schema attached, currently scores 10/10 at
+ten topics - no degradation from six. What does break is phrasing, in two
+reproducible ways: the **singular** ("est-ce qu'*un* conteneur est arrêté ?") makes
+the model ask *which* container instead of calling anything, and **negation**
+("depuis quand X *n'est-il plus* en ligne ?") makes it answer nothing at all. Both
+work stated positively and in the plural. Re-run the check when adding a topic, and
+when writing a suggestion.
+
+**What it can reach.** `/` is bind-mounted read-only at `/hostfs`: `/proc` and
+`/sys` report the host from inside a container anyway, but `statvfs` can only
+measure a filesystem this process can itself see, which is what `disk` needs.
+
+The Docker socket is mounted `:ro`, the same way `homepage` already mounts it -
+but be clear about what that buys: `:ro` protects the socket *inode*, not the
+Docker API, and anything holding an open socket can still `POST
+/containers/create` and get host root. What actually constrains this server is its
+own code - it only ever issues `GET`, to two paths, and `services` is the only
+caller. There is likewise no endpoint that accepts a command, a path or a pattern:
+the model picks a topic from a closed list and each topic maps to fixed code, so a
+prompt injection has nothing to steer. The container itself runs `read_only` with
+`no-new-privileges`.
+
+`services`, `restarts` and `errors` filter the container list on
+`com.docker.compose.project=$COMPOSE_PROJECT` (passed in from
+`COMPOSE_PROJECT_NAME`, defaulting to `pi-web`). The socket is the host's, so
+without that filter the count also covers containers that have nothing to do with
+this stack - and any stray `docker run` left in `Exited` would be reported as
+something needing attention.
+
+`errors` reads container logs, which is the one place where "the model picks a
+topic, not a target" earns its keep: it only ever reads the tail of containers it
+has *already* found stopped or unhealthy. The model cannot name what gets read, so
+there is no way to ask it for the logs of something else.
+
+`backups` reads Backrest's own operation log,
+`$DATA_LOCATION/backrest/data/oplog.sqlite`, opened `mode=ro`. That directory is
+bind-mounted straight in at `/run/backrest` rather than reached through `/hostfs`,
+because `DATA_LOCATION` is relative to the project directory by default and a
+relative path means nothing against the host root - the directory, not the file,
+because the oplog does not exist until Backrest's first run and Docker would
+otherwise create a directory in its place.
+Backrest's repos live on a remote, so restic would want their password, and the
+log answers "did last night run" without one. Two things to know: the status codes
+come from `proto/v1/operations.proto`, where `WARNING` is declared before `ERROR`
+but numbered *after* the cancellations (reading declaration order off the binary
+gets it backwards - `ERROR` is 4); and a WAL database opened read-only can refuse
+the read if the WAL needs replaying, which surfaces as `backup log unreadable`
+rather than an error.
+
+`devices` reads headscale's node API - the tailnet is self-hosted, so there is no
+Tailscale SaaS call - reusing the API key `homepage`'s headscale widget already
+holds, mounted read-only at `/run/secrets/headscale_api_key`. Those keys expire, so
+this and the Homepage widget break together. It is also the one topic that needs
+the `frontend` network, since headscale listens there; the container makes egress
+GETs to a fixed URL and accepts no URL of its own, so what widens is the reachable
+surface, not the steerable one.
+
+Note what `devices` does *not* have: a parameter naming a device. Ten devices fit
+in eleven digested lines, so "when was the iPad last online?" is answered by the
+model reading its own tool result - no free-form target, and the closed-enum
+property survives. Past `DEVICE_LINES` devices the offline ones are trimmed
+oldest-first and the reply says how many it dropped.
+
+There is deliberately no `network` topic. It existed briefly and was dropped: the
+default route, the link speed and `wlan0: down` are static configuration, and
+traffic *since boot* is a number nothing can be done with - a rate would be needed,
+and beszel and the Homepage widget already graph one. The question it could not
+answer either way is which *service* is using the bandwidth, which would need
+per-container counters.
+
+To give a *different* model the same capability, add `server:pi-system` to its
+`toolIds` in **Workspace → Models**; the tool server itself is registered once,
+globally. To add a topic, extend `TOPICS` and the `Topic` literal in
+`config/system-tools/app.py`; to report another drive, add its mount point to
+`FILESYSTEMS` in the same file (one that is not mounted is skipped, so a drive
+that comes and goes is safe to list). Either way, `docker compose build
+system-tools` afterwards.
+
+**The tiles on the new-chat screen.** Open WebUI ships six suggestions of its own
+- vocabulary drills, the Roman Empire, options trading - which advertise a model
+this box does not run and never touch the tool, so nobody discovers the assistant
+can be asked about the machine. `scripts/open-webui-bootstrap.sh` replaces them
+with nine that each map to a topic, in the stack's `DEFAULT_LANGUAGE`: free disk
+space, whether every service is up, a general status, CPU temperature and load,
+uptime, who is online on the tailnet, last night's backup, recent restarts, and the
+errors of whatever is failing.
+
+They are written to `suggestion_prompts` on the model rather than to the global
+`ui.prompt_suggestions`, because the frontend reads
+`model.info.meta.suggestion_prompts` first and only falls back to the global
+list - a suggestion that assumes the status tool exists belongs to the model the
+tool is attached to. Edit them in **Workspace → Models → gemma-4-e2b-it**, or in
+the `SUGGESTIONS` heredoc in the script; the `pi-pcloud.prompt_suggestions`
+marker means a UI edit is never overwritten.
+
+Each wording was checked against `llama-server` with the tool schema attached,
+because a prompt that reads well is not necessarily one this 4B model turns into
+a call: "est-ce qu'un conteneur est arrêté ou en mauvaise santé ?" makes it ask
+*which* container instead of calling anything, where the plural "est-ce que tous
+les services tournent correctement ?" calls `services` every time. Worth
+re-checking a new suggestion the same way.
 
 **Language.** One `.env` variable, `DEFAULT_LANGUAGE`, sets the language of
 everything in the stack that has to choose one, as a BCP 47 tag. It defaults to
@@ -303,6 +481,7 @@ everything in the stack that has to choose one, as a BCP 47 tag. It defaults to
 |-----------|-----|
 | Open WebUI's interface | `DEFAULT_LOCALE`, for users who have not picked a language themselves |
 | Which Piper voice reads answers aloud | matched against the voices baked into the image |
+| The new-chat suggestion tiles | written in that language by `scripts/open-webui-bootstrap.sh` |
 
 `fr-FR` and `en-US` are the two tags with voices shipped. Anything else still
 works - the interface has its own translations, and Piper picks the closest

--- a/scripts/headscale-pre-start.sh
+++ b/scripts/headscale-pre-start.sh
@@ -16,6 +16,7 @@ main() {
     # causing headplane to crash with EISDIR on startup.
     HEADPLANE_CONFIG="$PROJECT_DIR/config/headplane/config.yaml"
     HEADPLANE_API_KEY_FILE="$PROJECT_DIR/config/headplane/headscale_api_key"
+    HOMEPAGE_API_KEY_FILE="$PROJECT_DIR/config/homepage/secrets/headscale_api_key"
     mkdir -p "$(dirname "$HEADPLANE_CONFIG")"
     if [ -d "$HEADPLANE_CONFIG" ]; then
         log "WARNING: headplane config.yaml is a directory (Docker bind-mount artifact). Removing..."
@@ -35,6 +36,24 @@ main() {
         printf 'pending-headscale-api-key\n' > "$HEADPLANE_API_KEY_FILE"
         chmod 600 "$HEADPLANE_API_KEY_FILE" 2>/dev/null || true
         log "Created placeholder $HEADPLANE_API_KEY_FILE (will be populated by headscale-init.sh)"
+    fi
+
+    # Same again for the second Headscale key, the one homepage's widget and the
+    # system-tools `devices` topic both bind-mount. It is created by
+    # homepage-widgets-bootstrap.sh, which runs in ExecStartPost - i.e. after the
+    # `docker compose up` that bind-mounts it - so on a fresh install Docker gets
+    # there first and makes a directory, which write_secret can then never
+    # replace. Left empty on purpose: that bootstrap only mints a key when the
+    # file has no content in it.
+    mkdir -p "$(dirname "$HOMEPAGE_API_KEY_FILE")"
+    if [ -d "$HOMEPAGE_API_KEY_FILE" ]; then
+        log "WARNING: homepage headscale_api_key is a directory (Docker bind-mount artifact). Removing..."
+        rm -rf "$HOMEPAGE_API_KEY_FILE"
+    fi
+    if [ ! -e "$HOMEPAGE_API_KEY_FILE" ]; then
+        touch "$HOMEPAGE_API_KEY_FILE"
+        safe_chmod 600 "$HOMEPAGE_API_KEY_FILE"
+        log "Created empty $HOMEPAGE_API_KEY_FILE (will be populated by homepage-widgets-bootstrap.sh)"
     fi
 
     if [ ! -f "$POLICY_TEMPLATE_FILE" ]; then

--- a/scripts/open-webui-bootstrap.sh
+++ b/scripts/open-webui-bootstrap.sh
@@ -36,6 +36,21 @@ LLAMA_MODEL="gemma-4-e2b-it"
 DEFAULTS_MARKER="pi-pcloud.local_ai_defaults"
 # Bump when the defaults below change, to seed the new ones once.
 DEFAULTS_VERSION='"2"'
+# The workspace row for the model carries its own marker: writing it needs an
+# admin account to own it, which a fresh install does not have until the first
+# SSO login, while the config keys above apply from the first boot. One marker
+# across both would record the half that could not run yet as done.
+MODEL_MARKER="pi-pcloud.local_ai_model_defaults"
+MODEL_VERSION='"1"'
+# Before llama.cpp, the local model came from Ollama and carried its naming
+# convention; the switch renamed it to LLAMA_MODEL above and left the old
+# workspace row behind. Inert - get_all_models drops a base-model override whose
+# base is not served by any backend - but it shows up in the model table and in
+# every backup after it. Removed once, and again after a database restore brings
+# it back, which a one-off DELETE would not cover.
+STALE_MODEL_MARKER="pi-pcloud.ollama_model_cleanup"
+STALE_MODEL_VERSION='"1"'
+STALE_MODEL_ID="gemma4:e2b"
 # The text-to-speech settings carry their own marker, so bumping one group's
 # version never re-imposes the other's.
 TTS_MARKER="pi-pcloud.local_tts_defaults"
@@ -68,6 +83,77 @@ STT_MODEL="parakeet-tdt-0.6b-v3"
 # still holds Open WebUI's own empty default, which means "follow the browser".
 LOCALE_MARKER="pi-pcloud.default_locale"
 LOCALE_VERSION="\"1-$DEFAULT_LANGUAGE\""
+# Open access to anyone Authelia lets in, rather than Open WebUI's approval queue.
+ACCESS_MARKER="pi-pcloud.open_access"
+ACCESS_VERSION='"2"'
+# The system-status tool server (config/system-tools), on the ai network.
+TOOLS_MARKER="pi-pcloud.system_tools"
+TOOLS_VERSION='"1"'
+TOOLS_URL="http://system-tools:8000"
+# Stable id: the tool is attached to a model as "server:<id>", so it must not
+# change between runs or the reference on the model breaks.
+TOOLS_ID="pi-system"
+# The splash-screen suggestions.
+SUGGESTIONS_MARKER="pi-pcloud.prompt_suggestions"
+# The language is part of the version, like the TTS marker above: changing
+# DEFAULT_LANGUAGE swaps the tiles once, re-running does nothing.
+SUGGESTIONS_VERSION="\"4-$DEFAULT_LANGUAGE\""
+# `memory` is left out because `overview` already reports RAM. Quoted heredocs,
+# so neither the apostrophes nor the double quotes need escaping. One function
+# per language rather than one case with heredocs inside it, which sh parses but
+# nobody enjoys reading.
+suggestions_fr() { cat <<'JSON'
+[
+  {"title": ["Combien d'espace disque", "reste-t-il ?"],
+   "content": "Combien d'espace disque reste-t-il sur le serveur ?"},
+  {"title": ["Est-ce que tout tourne", "correctement ?"],
+   "content": "Est-ce que tous les services du serveur tournent correctement ?"},
+  {"title": ["Donne-moi l'état", "du serveur"],
+   "content": "Donne-moi un état général du serveur."},
+  {"title": ["Le Pi chauffe-t-il ?", "température et charge"],
+   "content": "Quelle est la température du CPU et la charge en ce moment ?"},
+  {"title": ["Depuis quand", "le serveur tourne-t-il ?"],
+   "content": "Depuis combien de temps le serveur tourne-t-il ?"},
+  {"title": ["Qui est en ligne", "sur le tailnet ?"],
+   "content": "Quels appareils sont actuellement en ligne sur le tailnet ?"},
+  {"title": ["La sauvegarde de cette nuit", "est-elle passée ?"],
+   "content": "Est-ce que la sauvegarde de cette nuit est passée ?"},
+  {"title": ["Quelque chose a-t-il", "redémarré récemment ?"],
+   "content": "Est-ce que quelque chose a redémarré récemment ?"},
+  {"title": ["Montre-moi les erreurs", "des services en panne"],
+   "content": "Montre-moi les erreurs des services en panne."}
+]
+JSON
+}
+
+suggestions_en() { cat <<'JSON'
+[
+  {"title": ["How much disk space", "is left?"],
+   "content": "How much disk space is left on the server?"},
+  {"title": ["Is everything", "running correctly?"],
+   "content": "Are all the services on the server running correctly?"},
+  {"title": ["Give me an overview", "of the server"],
+   "content": "Give me a general overview of the server."},
+  {"title": ["Is the Pi hot?", "temperature and load"],
+   "content": "What is the CPU temperature and the load right now?"},
+  {"title": ["How long has the server", "been up?"],
+   "content": "How long has the server been running?"},
+  {"title": ["Who is online", "on the tailnet?"],
+   "content": "Which devices are currently online on the tailnet?"},
+  {"title": ["Did last night's", "backup succeed?"],
+   "content": "Did last night's backup succeed?"},
+  {"title": ["Has anything", "restarted recently?"],
+   "content": "Has anything restarted recently?"},
+  {"title": ["Show me the errors", "from failing services"],
+   "content": "Show me the errors from the services that are failing."}
+]
+JSON
+}
+
+case "$DEFAULT_LANGUAGE" in
+    fr*) SUGGESTIONS="$(suggestions_fr)" ;;
+    *)   SUGGESTIONS="$(suggestions_en)" ;;
+esac
 
 compose() {
     (cd "$PROJECT_DIR" && docker compose "$@")
@@ -131,6 +217,145 @@ BEGIN
 END
 \$\$;
 SQL
+}
+
+# 170 prompt tokens for the whole schema, against ~5000 for the built-in tools
+# disabled above.
+#
+# Idempotent by URL, so anything changed afterwards in Admin Settings > Tools
+# survives.
+register_tool_server() {
+    psql_owui -q <<SQL
+DO \$\$
+DECLARE
+    servers jsonb;
+    stamp   bigint := extract(epoch from now())::bigint;
+BEGIN
+    SELECT coalesce(value::jsonb, '[]'::jsonb) INTO servers
+        FROM config WHERE key = 'tool_server.connections';
+    servers := coalesce(servers, '[]'::jsonb);
+
+    IF EXISTS (
+        SELECT 1 FROM jsonb_array_elements(servers) AS s
+        WHERE s->>'url' = '$TOOLS_URL'
+    ) THEN
+        RETURN;
+    END IF;
+
+    servers := servers || jsonb_build_object(
+        'url',       '$TOOLS_URL',
+        'path',      'openapi.json',
+        'type',      'openapi',
+        -- Unauthenticated: the ai network is internal and this server only reads.
+        'auth_type', 'none',
+        'key',       '',
+        -- access_grants, or has_connection_access makes this admin-only; see
+        -- apply_open_access, which patches a connection created before this.
+        'config',    jsonb_build_object(
+                         'enable', true,
+                         'access_grants', \$g\$[{"principal_type": "user", "principal_id": "*", "permission": "read"}]\$g\$::jsonb
+                     ),
+        'info',      jsonb_build_object(
+                         'id',          '$TOOLS_ID',
+                         'name',        'Server status',
+                         'description', 'Disk, CPU, memory, containers, restarts, errors, backups and tailnet devices'
+                     )
+    );
+
+    INSERT INTO config (key, value, updated_at)
+        VALUES ('tool_server.connections', servers::json, stamp)
+        ON CONFLICT (key) DO UPDATE
+        SET value = EXCLUDED.value, updated_at = EXCLUDED.updated_at;
+END
+\$\$;
+SQL
+}
+
+# On the workspace entry, so the tool is offered without being ticked per chat.
+attach_tool_server() {
+    psql_owui -q <<SQL
+INSERT INTO model (id, user_id, base_model_id, name, meta, params, created_at, updated_at, is_active)
+SELECT
+    '$LLAMA_MODEL',
+    (SELECT id FROM "user" WHERE role = 'admin' ORDER BY created_at LIMIT 1),
+    NULL,
+    '$LLAMA_MODEL',
+    '{"capabilities": {"builtin_tools": false}, "toolIds": ["server:$TOOLS_ID"]}',
+    '{}',
+    extract(epoch from now())::bigint,
+    extract(epoch from now())::bigint,
+    true
+WHERE EXISTS (SELECT 1 FROM "user" WHERE role = 'admin')
+ON CONFLICT (id) DO UPDATE SET
+    meta = jsonb_set(
+        coalesce(model.meta::jsonb, '{}'::jsonb),
+        '{toolIds}',
+        coalesce(model.meta::jsonb->'toolIds', '[]'::jsonb) || '["server:$TOOLS_ID"]'::jsonb,
+        true
+    )::text,
+    updated_at = extract(epoch from now())::bigint
+WHERE NOT coalesce(model.meta::jsonb->'toolIds', '[]'::jsonb) ? 'server:$TOOLS_ID';
+SQL
+}
+
+# On the model rather than in ui.prompt_suggestions: the frontend reads
+# model.info.meta.suggestion_prompts first and only falls back to the global list,
+# and these assume the tool is attached.
+#
+# Each wording, in both languages, was checked against llama-server with the
+# schema attached - a prompt that reads well is not necessarily one this model
+# turns into a call. Both sets currently score 9/9, one distinct topic each.
+# Singular ("est-ce qu'un conteneur est arrêté ?") makes it ask which container,
+# and negation ("depuis quand X n'est-il plus en ligne ?") makes it answer with
+# nothing at all; both work stated positively and in the plural.
+#
+# Dollar-quoted so the French apostrophes need no doubling.
+apply_prompt_suggestions() {
+    psql_owui -q <<SQL
+INSERT INTO model (id, user_id, base_model_id, name, meta, params, created_at, updated_at, is_active)
+SELECT
+    '$LLAMA_MODEL',
+    (SELECT id FROM "user" WHERE role = 'admin' ORDER BY created_at LIMIT 1),
+    NULL,
+    '$LLAMA_MODEL',
+    -- toolIds too, or this path recreates the row without the tool the
+    -- suggestions depend on.
+    jsonb_build_object('capabilities', jsonb_build_object('builtin_tools', false),
+                       'toolIds', jsonb_build_array('server:$TOOLS_ID'),
+                       'suggestion_prompts', \$j\$$SUGGESTIONS\$j\$::jsonb)::text,
+    '{}',
+    extract(epoch from now())::bigint,
+    extract(epoch from now())::bigint,
+    true
+WHERE EXISTS (SELECT 1 FROM "user" WHERE role = 'admin')
+ON CONFLICT (id) DO UPDATE SET
+    meta = jsonb_set(
+        coalesce(model.meta::jsonb, '{}'::jsonb),
+        '{suggestion_prompts}',
+        \$j\$$SUGGESTIONS\$j\$::jsonb,
+        true
+    )::text,
+    updated_at = extract(epoch from now())::bigint;
+SQL
+}
+
+# For the groups whose work does not fit in one statement; apply_task_defaults,
+# apply_tts_defaults and apply_stt_defaults write their marker as part of theirs,
+# and apply_open_access writes its own inside its transaction.
+mark_seeded() {
+    psql_owui -q -c \
+        "INSERT INTO config (key, value, updated_at)
+             VALUES ('$1', '$2'::json, extract(epoch from now())::bigint)
+             ON CONFLICT (key) DO UPDATE
+             SET value = EXCLUDED.value, updated_at = EXCLUDED.updated_at;"
+}
+
+# Every write to the model row is guarded by `WHERE EXISTS (... role = 'admin')`.
+# On a fresh install nobody has signed in yet, so those statements would insert
+# nothing, exit 0, and still be marked as seeded - permanently.
+admin_present() {
+    psql_owui -tAc "SELECT EXISTS (SELECT 1 FROM \"user\" WHERE role = 'admin');" 2>/dev/null \
+        | tr -d '[:space:]'
 }
 
 # 't' once the given version of a settings group has been seeded.
@@ -202,12 +427,93 @@ ON CONFLICT (key) DO UPDATE
 SQL
 }
 
+# base_model_id IS NULL restricts this to what Open WebUI calls an override of a
+# base model - the shape the Ollama-era row has. A model someone built on top of
+# a base keeps a base_model_id and is left alone even if the id ever collided.
+# Chats keep their own copy of the model id and there is no foreign key to this
+# table, so an old conversation stays readable; it was already impossible to
+# continue, since nothing serves that model.
+drop_stale_ollama_model() {
+    psql_owui -q <<SQL
+DELETE FROM model WHERE id = '$STALE_MODEL_ID' AND base_model_id IS NULL;
+SQL
+}
+
+# DEFAULT_USER_ROLE is PersistentConfig: the value in compose.yaml only applies
+# to an instance that has never started, so the database still holds "pending".
+# Accounts already parked had passed Authelia, so release them too.
+#
+# The role alone is not enough; both grants below undo an admin-only default:
+#   - get_filtered_models keeps a model that has a workspace row only for its
+#     owner or a named grantee, and that row belongs to the admin - so every
+#     other account would get an empty model picker.
+#   - has_connection_access treats a tool server with no access_grants as
+#     admin-only, so a normal user would get invented answers, not tool calls.
+# ('user', '*', 'read') is the public-read shape the code documents, and stays
+# revocable in the UI.
+#
+# One transaction, with the marker written last: psql autocommits statement by
+# statement, so committing the marker first - as this used to - would record the
+# group as seeded even when the grant below failed, and the grants would then be
+# skipped forever behind a single WARNING.
+apply_open_access() {
+    psql_owui -q <<SQL
+BEGIN;
+
+INSERT INTO config (key, value, updated_at) VALUES
+    ('ui.default_user_role', '"user"'::json, extract(epoch from now())::bigint)
+ON CONFLICT (key) DO UPDATE
+    SET value = EXCLUDED.value, updated_at = EXCLUDED.updated_at;
+
+UPDATE "user" SET role = 'user' WHERE role = 'pending';
+
+INSERT INTO access_grant
+    (id, resource_type, resource_id, principal_type, principal_id, permission, created_at)
+VALUES
+    ('pi-pcloud-model-public-read', 'model', '$LLAMA_MODEL', 'user', '*', 'read',
+     extract(epoch from now())::bigint)
+ON CONFLICT (resource_type, resource_id, principal_type, principal_id, permission)
+    DO NOTHING;
+
+-- Dollar-quoted, so the JSON needs no doubled quotes.
+UPDATE config SET
+    value = (
+        SELECT jsonb_agg(
+            CASE WHEN server->>'url' = '$TOOLS_URL'
+                 THEN jsonb_set(
+                          server,
+                          '{config,access_grants}',
+                          \$g\$[{"principal_type": "user", "principal_id": "*", "permission": "read"}]\$g\$::jsonb,
+                          true
+                      )
+                 ELSE server
+            END
+        )
+        FROM jsonb_array_elements(config.value::jsonb) AS server
+    )::json,
+    updated_at = extract(epoch from now())::bigint
+WHERE key = 'tool_server.connections'
+  AND EXISTS (
+      SELECT 1 FROM jsonb_array_elements(config.value::jsonb) AS server
+      WHERE server->>'url' = '$TOOLS_URL'
+        AND coalesce(jsonb_array_length(server->'config'->'access_grants'), 0) = 0
+  );
+
+INSERT INTO config (key, value, updated_at) VALUES
+    ('$ACCESS_MARKER', '$ACCESS_VERSION'::json, extract(epoch from now())::bigint)
+ON CONFLICT (key) DO UPDATE
+    SET value = EXCLUDED.value, updated_at = EXCLUDED.updated_at;
+
+COMMIT;
+SQL
+}
+
 # Open WebUI fires an extra, invisible LLM call per message for each of these:
 # a chat title, chat tags, follow-up suggestions, a search query rewrite. Against
 # a cloud API that is free; against a Pi generating ~10 tok/s it multiplies the
 # wait for the answer the user is actually looking at, several times over, all
 # competing for the same three CPU threads. Off by default here.
-apply_defaults() {
+apply_task_defaults() {
     psql_owui -q <<SQL
 INSERT INTO config (key, value, updated_at) VALUES
     ('task.title.enable',                'false'::json,          extract(epoch from now())::bigint),
@@ -222,14 +528,17 @@ INSERT INTO config (key, value, updated_at) VALUES
 ON CONFLICT (key) DO UPDATE
     SET value = EXCLUDED.value, updated_at = EXCLUDED.updated_at;
 SQL
+}
 
-    # Built-in tools (time, memory, chats, notes, knowledge, channels) are on by
-    # default for every model, and their schemas are injected into the prompt of
-    # every message sent from the browser - about 5000 tokens, which is ~3
-    # minutes of prompt processing on this CPU before the model starts writing.
-    # A workspace entry for the model is the only place that default can be
-    # turned off, so create one. Attaching tools to a chat explicitly still
-    # works.
+# Built-in tools (time, memory, chats, notes, knowledge, channels) are on by
+# default for every model, and their schemas are injected into the prompt of
+# every message sent from the browser - about 5000 tokens, which is ~3
+# minutes of prompt processing on this CPU before the model starts writing.
+# A workspace entry for the model is the only place that default can be
+# turned off, so create one. Attaching tools to a chat explicitly still works.
+#
+# Needs an admin to own the row, hence the separate marker; see MODEL_MARKER.
+apply_model_defaults() {
     psql_owui -q <<SQL
 INSERT INTO model (id, user_id, base_model_id, name, meta, params, created_at, updated_at, is_active)
 SELECT
@@ -282,7 +591,7 @@ main() {
 
     if [ "$(marker_present "$DEFAULTS_MARKER" "$DEFAULTS_VERSION")" = "f" ]; then
         log "Seeding low-latency defaults (title/tags/follow-up generation off)"
-        if apply_defaults; then
+        if apply_task_defaults; then
             changed=1
         else
             log "WARNING: failed to seed Open WebUI defaults"
@@ -295,6 +604,15 @@ main() {
             changed=1
         else
             log "WARNING: failed to seed the Open WebUI default language"
+        fi
+    fi
+
+    if [ "$(marker_present "$STALE_MODEL_MARKER" "$STALE_MODEL_VERSION")" = "f" ]; then
+        log "Removing the leftover Ollama-era model row ($STALE_MODEL_ID)"
+        if drop_stale_ollama_model && mark_seeded "$STALE_MODEL_MARKER" "$STALE_MODEL_VERSION"; then
+            changed=1
+        else
+            log "WARNING: failed to remove the stale $STALE_MODEL_ID model row"
         fi
     fi
 
@@ -313,6 +631,55 @@ main() {
             changed=1
         else
             log "WARNING: failed to seed Open WebUI speech-to-text settings"
+        fi
+    fi
+
+    # The config keys above need no account. Everything below writes the model's
+    # workspace row or grants access to it, and every one of those statements is
+    # guarded by `WHERE EXISTS (... role = 'admin')` - so before the first SSO
+    # login they would write nothing, exit 0, and be marked as seeded forever.
+    if [ "$(admin_present)" != "t" ]; then
+        log "no Open WebUI account yet; leaving the rest to the next run"
+        [ "$changed" = "1" ] || return 0
+        log "Restarting open-webui to pick up the new configuration"
+        compose restart open-webui >/dev/null 2>&1 || log "WARNING: could not restart open-webui"
+        wait_for_health_warning "pi-open-webui" 90 2 || true
+        return 0
+    fi
+
+    if [ "$(marker_present "$MODEL_MARKER" "$MODEL_VERSION")" = "f" ]; then
+        log "Turning the built-in tools off on $LLAMA_MODEL (~5000 prompt tokens)"
+        if apply_model_defaults && mark_seeded "$MODEL_MARKER" "$MODEL_VERSION"; then
+            changed=1
+        else
+            log "WARNING: failed to seed the $LLAMA_MODEL workspace row"
+        fi
+    fi
+
+    if [ "$(marker_present "$TOOLS_MARKER" "$TOOLS_VERSION")" = "f" ]; then
+        log "Registering the system-status tool server and attaching it to $LLAMA_MODEL"
+        if register_tool_server && attach_tool_server && mark_seeded "$TOOLS_MARKER" "$TOOLS_VERSION"; then
+            changed=1
+        else
+            log "WARNING: failed to register the system-status tool server"
+        fi
+    fi
+
+    if [ "$(marker_present "$ACCESS_MARKER" "$ACCESS_VERSION")" = "f" ]; then
+        log "Granting Open WebUI access to every SSO user (no admin approval)"
+        if apply_open_access; then
+            changed=1
+        else
+            log "WARNING: failed to open Open WebUI access to every SSO user"
+        fi
+    fi
+
+    if [ "$(marker_present "$SUGGESTIONS_MARKER" "$SUGGESTIONS_VERSION")" = "f" ]; then
+        log "Seeding the new-chat suggestions that exercise the status tool"
+        if apply_prompt_suggestions && mark_seeded "$SUGGESTIONS_MARKER" "$SUGGESTIONS_VERSION"; then
+            changed=1
+        else
+            log "WARNING: failed to seed the Open WebUI prompt suggestions"
         fi
     fi
 


### PR DESCRIPTION
The assistant could not say anything about the machine it runs on. It can now — "how much disk is left?", "is anything down?", "did last night's backup run?".

## The tool server

`config/system-tools/` is an OpenAPI tool server on the `ai` network exposing **one** operation, `get_system_status(topic)`, with ten topics: `overview`, `disk`, `cpu`, `memory`, `uptime`, `services`, `restarts`, `errors`, `backups`, `devices`.

**One operation and not ten**, because tool schemas are injected into the prompt of *every* message, and at ~40 tok/s of prompt processing that is the latency budget — it is the reason the built-in tools are off here at all, they cost ~5000 tokens (~3 minutes before the model writes a word). This one is 170. The difference is measured: 6 → 10 topics cost 113 → 170 tokens, about **+14 per topic**, where a single extra *operation* costs **+72**. So a new capability becomes a topic, never a second operation.

Replies are digested for the same reason, and it matters more than the schema does since a reply is re-processed on every later turn: `df -h` alone is ~400 tokens of column padding, so nothing returns raw command output.

Topic selection is checked against `llama-server` with the schema attached — one prompt per topic, currently 10/10 at ten topics, no degradation from six.

## Attack surface

The model picks a topic from a **closed list** and each topic maps to fixed code, so a prompt injection has nothing to steer: no endpoint accepts a command, a path, a pattern or a URL.

- `errors` only reads the tail of containers it has *already* found stopped or unhealthy — the model cannot name what gets read.
- `devices` has no parameter naming a device; ten devices fit in eleven digested lines, so the model answers "when was the iPad last online?" by reading its own tool result.
- The container runs `read_only` with `no-new-privileges`. `/` is bind-mounted read-only at `/hostfs` because `statvfs` can only measure a filesystem this process can itself see.
- The Docker socket is `:ro`, the same way `homepage` already mounts it — but that protects the socket *inode*, not the API. What actually constrains this server is its own code: `GET` only, to two paths.

## Three admin-only defaults that had to be opened up

The assistant was unusable for everyone except the admin, for three separate reasons:

- `ui.default_user_role` was `pending`, parking every SSO login behind an approval screen — pointless when Authelia already decides who reaches the host.
- `get_filtered_models` keeps a model that has a workspace row only for its owner. That row exists here to turn the builtin tools off and it belongs to the admin, so **every other account got an empty model picker**.
- `has_connection_access` treats a tool server with no `access_grants` as admin-only, so a normal user clicking a suggestion would get an invented answer with no tool call.

Both grants are wildcard public read — `('user', '*', 'read')`, the shape the code itself documents as public — and stay visible and revocable in the UI. Admin rights are still granted deliberately.

## New-chat suggestions

The nine tiles replace Open WebUI's own (vocabulary drills, the Roman Empire, options trading), which advertise a model this box does not run and never touch the tool.

Each wording was checked against `llama-server` with the schema attached, because a prompt that reads well is not necessarily one a 4B model turns into a call: the **singular** ("est-ce qu'*un* conteneur est arrêté ?") makes it ask *which* container instead of calling anything, and **negation** ("depuis quand X *n'est-il plus* en ligne ?") makes it answer nothing at all. All nine are positive and plural.

They live on the model's `suggestion_prompts`, not the global `ui.prompt_suggestions`, because the frontend reads the model's first — a suggestion that assumes the status tool exists belongs to the model the tool is attached to.

## Also here, since the same script and the same run own them

- The bootstrap script is split so that settings needing an admin account to own a row are gated behind `admin_present` and carry their own markers. Previously they would have run before the first SSO login — inserting nothing, exiting 0, and being **marked as seeded forever**.
- `apply_open_access` commits its marker inside the transaction, so a failed grant no longer records the group as done and skips it behind a single WARNING.
- The leftover Ollama-era model row (`gemma4:e2b`) is removed. Inert, but it shows in the model table and in every backup after it.
- `headscale-pre-start.sh` keeps `config/homepage/secrets/headscale_api_key` a file. It is created by a bootstrap running in `ExecStartPost`, so on a fresh install the `compose up` that bind-mounts it gets there first and makes a *directory*, which nothing can then replace. The `devices` topic reuses that same key.

Touches `compose.yaml` and `scripts/open-webui-bootstrap.sh` alongside #209 and #210 — expect small merge conflicts depending on order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)