### PR TITLE
fix(parakeet): deprioritize it for the OOM killer like its siblings

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1757,6 +1757,7 @@ services:
     # measured). The headroom is what stops a long upload from being an OOM:
     # before openai_api.py windowed them, a 120s pass went past 2GB.
     mem_limit: 2560m
+    oom_score_adj: *oom-score-deprioritize
 
   # Serves the host's status to the local model as an OpenAPI tool; see
   # config/system-tools/app.py. / is mounted at /hostfs because statvfs cannot


### PR DESCRIPTION
## What

Adds `oom_score_adj: *oom-score-deprioritize` to the `parakeet` service, right after `mem_limit` to match how its siblings are laid out.

## Why

`parakeet` was the only AI service without it. Every other container on the `ai` network carries the anchor:

| Service | `oom_score_adj` before | after |
|---|---|---|
| `llama-cpp` | 500 | 500 |
| `piper` | 500 | 500 |
| `system-tools` | 500 | 500 |
| `open-webui` | 500 | 500 |
| `parakeet` | *(unset → 0)* | **500** |

Left unset, the kernel scores it at 0, which under host memory pressure makes the 2560m transcription container *more* attractive to the OOM killer than the services it exists to serve — and than everything else deprioritized in the stack. Speech-to-text is the most disposable thing on the box; it should be among the first to go, not protected relative to `llama-cpp`.

The line was written as part of the original Parakeet work but lost when that work was split into #210.

## Test

- `docker compose config --quiet` passes.
- Resolved config confirms `parakeet -> 500`, matching `piper`, `llama-cpp`, `system-tools` and `open-webui`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)