### PR TITLE
fix(ci): authenticate ghcr pulls and retry them instead of failing the run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,11 @@ on:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   validate:
@@ -90,6 +91,30 @@ jobs:
           test ! -d ./config/headplane/config.yaml
           test -f ./config/headscale/config.yaml
           test -f ./config/headscale/policy.hujson
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Pull images
+        env:
+          # Override the job-wide quiet progress so a failing pull names its image.
+          COMPOSE_PROGRESS: plain
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if docker compose pull --ignore-buildable --policy missing; then
+              exit 0
+            fi
+            delay=$((attempt * 20))
+            echo "::warning::Pull attempt ${attempt}/3 failed; retrying in ${delay}s"
+            sleep "${delay}"
+          done
+          echo "::error::Image pull failed after 3 attempts"
+          exit 1
 
       - name: Start stack and run smoke checks
         run: |


### PR DESCRIPTION
## Why

CI on `main` failed at [run 32230401942](https://github.com/florianajir/pi-pcloud/actions/runs/32230401942) — not on the change it was testing (an `oom_score_adj` value), but on a registry rate limit while pulling images:

```
toomanyrequests: retry-after: 817.298µs, allowed: 44000/minute
```

The smoke test pulls all 24 images anonymously in a single `docker compose up --pull missing`, so one throttled image takes the whole job down. The limiter asked for a sub-millisecond backoff and compose gave up anyway.

It was triggered by the PR run and the merge's push run starting within a second of each other and pulling the full stack concurrently from the same runner IP.

## What

- **Log in to ghcr.io** with `GITHUB_TOKEN` (`packages: read`). Authenticated pulls get a much higher quota than the shared-runner-IP anonymous one. Covers 7 of the 23 remote images; no secrets required.
- **Move the pull into its own retrying step** — three attempts with 20s/40s backoff. This is the registry-agnostic part, and the only thing covering the 14 Docker Hub images, for which the repo has no credentials (`gh secret list` is empty).
- **`COMPOSE_PROGRESS: plain` on that step only**, so a failing pull names its image. The job-wide `quiet` is why the current log doesn't say which one was throttled.
- **Only cancel in-progress runs for PRs.** Unrelated to the pull failure, but back-to-back merges were cancelling each other — four consecutive `main` commits have no CI result at all. Superseded PR runs still get cancelled.

## Verified locally

- `yamllint -c .yamllint .` passes (the command the validate job runs).
- `--ignore-buildable` genuinely excludes the buildable `pi-system-tools:local` ("Skipped Image can be built"); without it the pull fails with `pull access denied`. Confirmed against a throwaway compose file — this flag missing would have broken CI outright on a clean runner.
- `docker compose pull` exits `1` on failure and `0` on skip, so the retry loop actually fires.
- `--policy missing` skips already-present images.

## Not addressed

The PR run and the merge's push run still overlap. They have different refs *and* different SHAs under squash merge, so no `concurrency` key unifies them. The retries and the higher GHCR quota absorb the overlap instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
