### PR TITLE
fix(pihole): stop blocking the redirects behind sponsored and affiliate links

### DIFF
--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -343,6 +343,18 @@ cat /etc/resolv.conf                    # Should show Tailscale DNS
 networksetup -getdnsservers "Wi-Fi"     # Or VPN adapter
 ```
 
+### A link or a redirect leads nowhere
+
+Sponsored search results, newsletter links and affiliate links route through ad
+infrastructure, so the block lists catch them and the click dies on a blank page
+instead of just losing an ad. `scripts/pihole-bootstrap.sh` keeps an
+`ALLOW_LISTS` of the known offenders; add the domain there rather than only in
+the web UI, or the next rebuild loses it.
+
+To find the real culprit, check the Pi-hole query log for the click: the blocked
+domain is often not the one you typed. A status of *blocked (CNAME)* means an
+alias is at fault — `g.live.com` was blocked because it points at `g.msn.com`.
+
 ### High DNS latency
 
 **Causes:**

--- a/scripts/pihole-bootstrap.sh
+++ b/scripts/pihole-bootstrap.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-# Bootstrap Pi-hole: adds recommended block lists and updates gravity.
+# Bootstrap Pi-hole: adds recommended block lists, allows the click-redirect
+# domains they over-block, then updates gravity.
 # Uses the Pi-hole v6 REST API via docker exec curl.
 # Firebog "ticked" lists (low false-positive rate) — https://firebog.net
 # Safe to run multiple times — skips lists already present.
@@ -25,7 +26,6 @@ https://v.firebog.net/hosts/AdguardDNS.txt
 https://v.firebog.net/hosts/Admiral.txt
 https://raw.githubusercontent.com/anudeepND/blacklist/master/adservers.txt
 https://v.firebog.net/hosts/Easylist.txt
-https://pgl.yoyo.org/adservers/serverlist.php?hostformat=hosts&showintro=0&mimetype=plaintext
 https://raw.githubusercontent.com/FadeMind/hosts.extras/master/UncheckyAds/hosts
 https://raw.githubusercontent.com/bigdargon/hostsVN/master/hosts
 https://v.firebog.net/hosts/Easyprivacy.txt
@@ -39,6 +39,25 @@ https://raw.githubusercontent.com/FadeMind/hosts.extras/master/add.Risk/hosts
 https://phishing.army/download/phishing_army_blocklist_extended.txt
 https://raw.githubusercontent.com/Spam404/lists/master/main-blacklist.txt
 https://urlhaus.abuse.ch/downloads/hostfile/
+"
+
+# Click-redirect and CNAME collateral: domains the block lists catch as ad
+# infrastructure, but which sit in the middle of a user-initiated navigation.
+# Blocking them turns a click into a dead page rather than removing an ad.
+# Each one below was verified present in gravity, most in several lists at once
+# (including StevenBlack), so dropping lists cannot fix them — only an allow can.
+ALLOW_LISTS="
+g.msn.com
+www.googleadservices.com
+googleadservices.com
+clickserve.dartsearch.net
+awin1.com
+go.redirectingat.com
+click.linksynergy.com
+s.click.aliexpress.com
+trk.klclick.com
+analytics.google.com
+dit.whatsapp.net
 "
 
 # Run curl inside the Pi-hole container (has curl; avoids extra network hop).
@@ -84,6 +103,27 @@ add_list() {
     case "$http_code" in
         2*) log "Added: $url"; return 0 ;;
         *)  log "Already present or error (HTTP $http_code): $url"; return 1 ;;
+    esac
+}
+
+# Add an exact allow entry. Exact, not regex: an allow is a hole in the filter,
+# so it stays as narrow as the domain that was actually breaking.
+# Returns 0 if newly added, 1 if already present or on error.
+add_allow() {
+    local sid="$1"
+    local domain="$2"
+    local http_code
+    http_code=$(pihole_curl \
+        -o /dev/null \
+        -w "%{http_code}" \
+        -X POST \
+        -H "Content-Type: application/json" \
+        -H "sid: $sid" \
+        -d "{\"domain\":\"$domain\",\"comment\":\"click-redirect allow\",\"enabled\":true,\"groups\":[0]}" \
+        "$PIHOLE_API/domains/allow/exact")
+    case "$http_code" in
+        2*) log "Allowed: $domain"; return 0 ;;
+        *)  return 1 ;;
     esac
 }
 
@@ -133,6 +173,13 @@ main() {
         if add_list "$sid" "$url"; then
             newly_added=$((newly_added + 1))
         fi
+    done
+
+    # Allow entries take effect on the next list reload, not on a gravity
+    # rebuild, so they never need to trigger one on their own.
+    for domain in $ALLOW_LISTS; do
+        [ -z "$domain" ] && continue
+        add_allow "$sid" "$domain" || true
     done
 
     if [ "$newly_added" -gt 0 ]; then


### PR DESCRIPTION
The family resolves through this Pi-hole over Tailscale, so a false positive is a support call. Clicking a sponsored Google result or an X/Twitter link landed on a blank page — the click routes through ad infrastructure, so the block lists caught the *redirect* and killed the navigation instead of just removing an ad.

## Why dropping a list could not fix it

The instinct is to find "the strict list" and remove it. The overlap data kills that approach — every offending domain sits in 3–8 lists at once, `StevenBlack` included:

```
www.googleadservices.com  → StevenBlack, adaway, anudeepND, hostsVN
clickserve.dartsearch.net → StevenBlack, anudeepND, Prigent-Ads
analytics.google.com      → 7 lists
```

Meanwhile the allowlist was **empty**: 688k blocked domains, zero exceptions.

## Changes

**`ALLOW_LISTS` (new)** — 11 exact allows, every one verified present in gravity *and* actually queried in the last 14 days. Exact rather than regex: a hole in the filter stays as narrow as the domain that broke.

- 7 are pure 302 redirectors that render no ad content (`clickserve.dartsearch.net`, `awin1.com`, `go.redirectingat.com`, `click.linksynergy.com`, `s.click.aliexpress.com`, `trk.klclick.com`, `googleadservices.com` ×2)
- `analytics.google.com` is only GA's read console — collection stays blocked on `www.google-analytics.com` and `region1.google-analytics.com`
- `g.msn.com` is the interesting one: nothing ever requested it, but `g.live.com` is a CNAME onto it and was dying **7835 times in 14 days**, invisible in the UI because the blocked name is not the one queried (FTL status 9)
- `dit.whatsapp.net` — telemetry, allowed to stop an 8812-hit retry loop

**`pgl.yoyo.org` removed from `BLOCK_LISTS`** — the only list here blocking `t.co`. Its sole other unique contribution was `popunhot1.blogspot.com`: 2 domains of coverage traded for every X link in the family.

**`ad.doubleclick.net` deliberately absent** — it serves real creatives, and sponsored *search* clicks go through `googleadservices.com/pagead/aclk`, so allowing it would have bought ads for no fix. Same reasoning keeps `amazon-adsystem.com` blocked.

## Verification

Ran on the live stack, then reran to confirm idempotence (`All block lists already present, skipping gravity update`). 24 lists → 22, gravity 687 869 → 677 302, allowlist 0 → 11.

| Now resolves | Still `0.0.0.0` |
|---|---|
| `t.co`, `www.googleadservices.com`, `clickserve.dartsearch.net`, `g.live.com`, `awin1.com`, `go.redirectingat.com`, `click.linksynergy.com`, `s.click.aliexpress.com`, `trk.klclick.com`, `analytics.google.com`, `dit.whatsapp.net` | `ad.doubleclick.net`, `googleads.g.doubleclick.net`, `pagead2.googlesyndication.com`, `amazon-adsystem.com`, `www.google-analytics.com`, `app-measurement.com` |

Logins and essentials were never affected and were confirmed clean: `login.microsoftonline.com`, `graph.facebook.com`, `t.paypal.com`, `email.laposte.net`, `links.messages.doctolib.fr`, `cdn.jsdelivr.net`, `consent.cookiebot.com`.

`shellcheck` reports only the pre-existing SC3043 (`local` under `#!/bin/sh`), consistent with the rest of `scripts/`.

## Notes

- A hand-added list (`Turtlecute33/Toolz/d3host.txt`, never in this script) was found in the live install and removed by a direct API call. The script stays **add-only**, so it will not detect the next such drift — to audit: `docker exec pi-pihole pihole-FTL sqlite3 /etc/pihole/gravity.db "select address from adlist where comment != 'firebog';"`
- The residual cost is **tracking, not ads**: DNS cannot tell an `/aclk` path from a creative on the same host.
- `Prigent-Ads` and `hostsVN` show up in nearly every false positive found, but removing them unblocks nothing here (StevenBlack covers the same domains) and would cost 8166 unique domains. Left alone.
- Branched from `origin/main` rather than local `main`, which carries 2 unrelated unpushed commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
