### PR TITLE
fix(docker): pin upstream image tags and apk package versions

### DIFF
--- a/config/backrest/Dockerfile
+++ b/config/backrest/Dockerfile
@@ -1,2 +1,5 @@
 FROM ghcr.io/garethgeorge/backrest:v1.14.1
-RUN apk add --no-cache postgresql-client jq
+# postgresql-client is a virtual package, so the pin names its concrete provider.
+# pg_dump 18 dumps the stack's Postgres 16 fine (pg_dump supports older servers).
+# Exact pins fail the build when the 3.24 branch bumps a package — bump them here.
+RUN apk add --no-cache postgresql18-client=18.6-r0 jq=1.8.1-r0

--- a/config/beszel-agent/Dockerfile
+++ b/config/beszel-agent/Dockerfile
@@ -1,9 +1,11 @@
 # Extends the official beszel-agent image with smartmontools for S.M.A.R.T. support.
 # The agent binary is statically compiled Go, so it runs fine on Alpine.
-FROM henrygd/beszel-agent AS upstream
+# Kept in lockstep with the beszel hub tag in compose.yaml — bump both together.
+FROM henrygd/beszel-agent:0.18.7 AS upstream
 
 FROM alpine:3.24
-RUN apk add --no-cache smartmontools
+# Exact pin fails the build when the 3.24 branch bumps the package — bump it here.
+RUN apk add --no-cache smartmontools=7.5-r0
 COPY --from=upstream /agent /agent
 VOLUME ["/var/lib/beszel-agent"]
 ENTRYPOINT ["/agent"]


### PR DESCRIPTION
Fixes #35.

The issue asks to pin the `apk add smartmontools` in `config/beszel-agent/Dockerfile`, but that file had a bigger determinism hole: `FROM henrygd/beszel-agent` with no tag, so every rebuild could pull a different agent binary.

Changes:
- **beszel-agent**: pin the upstream stage to `henrygd/beszel-agent:0.18.7`, in lockstep with the hub tag in `compose.yaml` (bump both together). Pin `smartmontools=7.5-r0` (the issue's `7.4-r0` example predates the current 3.24 branch).
- **backrest**: same treatment for its unpinned `apk add`. `postgresql-client` is a virtual package, so the pin names the concrete provider `postgresql18-client=18.6-r0`, plus `jq=1.8.1-r0`. pg_dump 18 dumps the stack's Postgres 16 fine.

Trade-off, stated in comments at each pin: Alpine mirrors drop superseded package versions, so an exact pin fails the build when the 3.24 branch bumps a package. That's intentional — a loud build failure and a one-line pin bump instead of silent drift.

Verified locally: both images build, agent binary reports 0.18.7, smartctl 7.5 present, `pg_dump` (18.6) and `jq` (1.8.1) on PATH in the backrest image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)