### PR TITLE
refactor(scripts): extract common bootstrap logic into lib.sh

### DIFF
--- a/scripts/headscale-init.sh
+++ b/scripts/headscale-init.sh
@@ -17,13 +17,10 @@ check_headscale_ready() {
 
 wait_for_headscale() {
     log "Waiting for Headscale to be ready..."
-    for i in $(seq 1 $MAX_RETRIES); do
-        if check_headscale_ready; then
-            log "Headscale is ready"
-            return 0
-        fi
-        sleep $RETRY_INTERVAL
-    done
+    if wait_for_cmd "$MAX_RETRIES" "$RETRY_INTERVAL" check_headscale_ready; then
+        log "Headscale is ready"
+        return 0
+    fi
     log "ERROR: Headscale did not become ready in time"
     return 1
 }
@@ -55,15 +52,6 @@ create_preauthkey() {
         grep -o '"key": *"[^"]*"' | sed 's/"key": *"\([^"]*\)"/\1/'
 }
 
-create_headscale_api_key() {
-    raw_output=$(docker exec pi-headscale "$HEADSCALE_BIN" apikeys create --expiration 8760h --output json 2>/dev/null | tr -d '\r\n')
-    api_key=$(printf '%s' "$raw_output" | sed -n -E 's/^"([^"]+)"$/\1/p')
-    if [ -z "$api_key" ]; then
-        api_key=$(printf '%s' "$raw_output" | grep -oE '"(api_key|apiKey|key)"[[:space:]]*:[[:space:]]*"[^"]+"' | head -1 | sed -E 's/^"[^"]+"[[:space:]]*:[[:space:]]*"([^"]+)"$/\1/')
-    fi
-    printf '%s' "$api_key"
-}
-
 ensure_headplane_oidc_api_key() {
     local key_file="$PROJECT_DIR/config/headplane/headscale_api_key"
     local current_key=""
@@ -72,6 +60,12 @@ ensure_headplane_oidc_api_key() {
     mkdir -p "$(dirname "$key_file")"
 
     if [ -f "$key_file" ]; then
+        # An unreadable file (root-owned 600, non-root run) is not a missing
+        # key: minting a replacement would orphan it in headscale's key list.
+        if [ ! -r "$key_file" ]; then
+            log "ERROR: Cannot read $key_file (not running as root?)"
+            return 1
+        fi
         current_key=$(tr -d '\r\n' < "$key_file")
     fi
 
@@ -88,7 +82,12 @@ ensure_headplane_oidc_api_key() {
         return 1
     fi
 
-    printf '%s\n' "$new_key" > "$key_file"
+    # The caller wraps this function in `if !`, which disables set -e: a failed
+    # write must not fall through to the success log.
+    if ! printf '%s\n' "$new_key" > "$key_file"; then
+        log "ERROR: Failed to write $key_file; expire the unsaved key with 'headscale apikeys expire'"
+        return 1
+    fi
     chmod 600 "$key_file" 2>/dev/null || true
     HEADPLANE_OIDC_KEY_UPDATED=1
     log "Stored Headplane OIDC Headscale API key at $key_file"

--- a/scripts/homepage-widgets-bootstrap.sh
+++ b/scripts/homepage-widgets-bootstrap.sh
@@ -61,15 +61,6 @@ sync_prowlarr_key() {
 # --- Headscale: dedicated API key (can't be re-read once created, so only
 # make one the first time) + the tailscale client's node ID (can change if
 # the node re-registers, so refresh it every run). ---
-create_headscale_api_key() {
-    raw_output=$(docker exec pi-headscale headscale apikeys create --expiration 8760h --output json 2>/dev/null | tr -d '\r\n')
-    api_key=$(printf '%s' "$raw_output" | sed -n -E 's/^"([^"]+)"$/\1/p')
-    if [ -z "$api_key" ]; then
-        api_key=$(printf '%s' "$raw_output" | grep -oE '"(api_key|apiKey|key)"[[:space:]]*:[[:space:]]*"[^"]+"' | head -1 | sed -E 's/^"[^"]+"[[:space:]]*:[[:space:]]*"([^"]+)"$/\1/')
-    fi
-    printf '%s' "$api_key"
-}
-
 sync_headscale() {
     if ! container_is_running "pi-headscale"; then
         log "WARNING: pi-headscale not running; skipping Headscale widget key"

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -98,6 +98,26 @@ print(f'\$pbkdf2-sha512\$310000\${s}\${d}')
 
 # --- Container helpers ---
 
+compose() {
+    (cd "$PROJECT_DIR" && docker compose "$@")
+}
+
+# Silent generic retry loop; the caller logs around it.
+# Usage: wait_for_cmd <max_retries> <interval_seconds> <command...>
+wait_for_cmd() {
+    local max_retries="$1"
+    local interval="$2"
+    shift 2
+
+    for i in $(seq 1 "$max_retries"); do
+        if "$@" >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep "$interval"
+    done
+    return 1
+}
+
 # Usage: wait_for_container <name> [max_retries] [interval_seconds]
 wait_for_container() {
     local name="$1"
@@ -141,6 +161,18 @@ container_is_running() {
     docker ps --format '{{.Names}}' | grep -q "^${name}$"
 }
 
+# Mint a 1-year Headscale API key. Headscale's json output moved the key
+# between a bare string and an object across versions, hence the two parses.
+create_headscale_api_key() {
+    local raw_output api_key
+    raw_output=$(docker exec pi-headscale "${HEADSCALE_BIN:-headscale}" apikeys create --expiration 8760h --output json 2>/dev/null | tr -d '\r\n')
+    api_key=$(printf '%s' "$raw_output" | sed -n -E 's/^"([^"]+)"$/\1/p')
+    if [ -z "$api_key" ]; then
+        api_key=$(printf '%s' "$raw_output" | grep -oE '"(api_key|apiKey|key)"[[:space:]]*:[[:space:]]*"[^"]+"' | head -1 | sed -E 's/^"[^"]+"[[:space:]]*:[[:space:]]*"([^"]+)"$/\1/')
+    fi
+    printf '%s' "$api_key"
+}
+
 # Like wait_for_health, but a timeout is a warning rather than an error.
 # Usage: wait_for_health_warning <name> [max_retries] [interval_seconds]
 wait_for_health_warning() {
@@ -169,7 +201,7 @@ authelia_container_has_oidc_materials() {
         return 1
     fi
 
-    (cd "$PROJECT_DIR" && docker compose exec -T authelia sh -ec "[ -r /config/secrets/oidc_${client_id}_secret.txt ] && grep -q \"client_id: ${client_id}\" /config/configuration.yml" >/dev/null 2>&1)
+    compose exec -T authelia sh -ec "[ -r /config/secrets/oidc_${client_id}_secret.txt ] && grep -q \"client_id: ${client_id}\" /config/configuration.yml" >/dev/null 2>&1
 }
 
 # Usage: ensure_authelia_oidc_materials <client_id> <display_name> [max_retries] [interval_seconds]
@@ -214,7 +246,7 @@ ensure_authelia_oidc_materials() {
 
     if container_is_running "pi-authelia"; then
         log "Restarting Authelia to apply OIDC client updates"
-        if (cd "$PROJECT_DIR" && docker compose restart authelia >/dev/null); then
+        if compose restart authelia >/dev/null; then
             wait_for_health_warning "pi-authelia" "$max_retries" "$interval" || true
         else
             log "WARNING: Failed to restart Authelia automatically"
@@ -258,7 +290,7 @@ get_oidc_secret() {
         return 0
     fi
 
-    secret_value="$(cd "$PROJECT_DIR" && docker compose exec -T authelia sh -ec "cat /config/secrets/oidc_${client_name}_secret.txt" 2>/dev/null | tr -d '\r\n')"
+    secret_value="$(compose exec -T authelia sh -ec "cat /config/secrets/oidc_${client_name}_secret.txt" 2>/dev/null | tr -d '\r\n')"
     if [ -n "$secret_value" ]; then
         printf '%s' "$secret_value"
         return 0

--- a/scripts/nextcloud-oidc-bootstrap.sh
+++ b/scripts/nextcloud-oidc-bootstrap.sh
@@ -15,13 +15,10 @@ OIDC_CLIENT_ID="${OIDC_CLIENT_ID:-nextcloud}"
 
 wait_for_occ() {
     log "Waiting for Nextcloud OCC to be ready..."
-    for i in $(seq 1 $MAX_RETRIES); do
-        if docker exec "$NEXTCLOUD_CONTAINER" php occ status >/dev/null 2>&1; then
-            log "Nextcloud OCC is ready"
-            return 0
-        fi
-        sleep "$RETRY_INTERVAL"
-    done
+    if wait_for_cmd "$MAX_RETRIES" "$RETRY_INTERVAL" docker exec "$NEXTCLOUD_CONTAINER" php occ status; then
+        log "Nextcloud OCC is ready"
+        return 0
+    fi
 
     log "ERROR: Nextcloud OCC did not become ready in time"
     return 1

--- a/scripts/open-webui-bootstrap.sh
+++ b/scripts/open-webui-bootstrap.sh
@@ -131,10 +131,6 @@ case "$DEFAULT_LANGUAGE" in
     *)   SUGGESTIONS="$(suggestions_en)" ;;
 esac
 
-compose() {
-    (cd "$PROJECT_DIR" && docker compose "$@")
-}
-
 psql_owui() {
     compose exec -T postgres psql -v ON_ERROR_STOP=1 -U postgres -d open-webui "$@"
 }

--- a/scripts/prowlarr-bootstrap.sh
+++ b/scripts/prowlarr-bootstrap.sh
@@ -62,13 +62,10 @@ get_api_key() {
 
 wait_for_prowlarr() {
     log "Waiting for Prowlarr API..."
-    for i in $(seq 1 $MAX_RETRIES); do
-        if px_curl -f -H "X-Api-Key: $KEY" "$API/system/status" >/dev/null 2>&1; then
-            log "Prowlarr API is ready"
-            return 0
-        fi
-        sleep "$RETRY_INTERVAL"
-    done
+    if wait_for_cmd "$MAX_RETRIES" "$RETRY_INTERVAL" px_curl -f -H "X-Api-Key: $KEY" "$API/system/status"; then
+        log "Prowlarr API is ready"
+        return 0
+    fi
     log "WARNING: Prowlarr API did not become ready in time"
     return 1
 }
@@ -141,13 +138,7 @@ ensure_tag() {
 # Wait until FlareSolverr answers, else Prowlarr's connection test on save fails
 # (Chrome needs ~45s to init on a fresh boot).
 wait_for_flaresolverr() {
-    for i in $(seq 1 $MAX_RETRIES); do
-        if px_curl -f "${FLARESOLVERR_HOST%/}/health" >/dev/null 2>&1; then
-            return 0
-        fi
-        sleep "$RETRY_INTERVAL"
-    done
-    return 1
+    wait_for_cmd "$MAX_RETRIES" "$RETRY_INTERVAL" px_curl -f "${FLARESOLVERR_HOST%/}/health"
 }
 
 ensure_flaresolverr_proxy() {

--- a/scripts/qbittorrent-bootstrap.sh
+++ b/scripts/qbittorrent-bootstrap.sh
@@ -25,13 +25,10 @@ qb_curl() {
 
 wait_for_qbittorrent() {
     log "Waiting for qBittorrent WebUI to be ready..."
-    for i in $(seq 1 $MAX_RETRIES); do
-        if qb_curl -f "$QB_API/app/webapiVersion" >/dev/null 2>&1; then
-            log "qBittorrent WebUI is ready"
-            return 0
-        fi
-        sleep "$RETRY_INTERVAL"
-    done
+    if wait_for_cmd "$MAX_RETRIES" "$RETRY_INTERVAL" qb_curl -f "$QB_API/app/webapiVersion"; then
+        log "qBittorrent WebUI is ready"
+        return 0
+    fi
     log "ERROR: qBittorrent WebUI did not become ready in time"
     return 1
 }

--- a/scripts/rotate-password.sh
+++ b/scripts/rotate-password.sh
@@ -97,10 +97,6 @@ confirm() {
     [ "$reply" = "yes" ] || { echo "Aborted"; exit 1; }
 }
 
-compose() {
-    (cd "$PROJECT_DIR" && docker compose "$@")
-}
-
 recreate() {
     local service="$1"
     local container="${2:-pi-$service}"

--- a/scripts/uptime-kuma-bootstrap.sh
+++ b/scripts/uptime-kuma-bootstrap.sh
@@ -13,22 +13,6 @@ PYTHON_IMAGE="python:3.12-slim"
 MAX_RETRIES=90
 RETRY_INTERVAL=2
 
-wait_for_kuma_health() {
-    local status
-
-    log "Waiting for Uptime Kuma health status..."
-    for i in $(seq 1 $MAX_RETRIES); do
-        status=$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' pi-uptime-kuma 2>/dev/null || true)
-        if [ "$status" = "healthy" ]; then
-            log "Uptime Kuma container is healthy"
-            return 0
-        fi
-        sleep "$RETRY_INTERVAL"
-    done
-    log "ERROR: Uptime Kuma container did not become healthy in time"
-    return 1
-}
-
 main() {
     log "=== Uptime Kuma Bootstrap ==="
 
@@ -37,7 +21,7 @@ main() {
     fi
 
     wait_for_container "pi-uptime-kuma" "$MAX_RETRIES" "$RETRY_INTERVAL"
-    wait_for_kuma_health
+    wait_for_health "pi-uptime-kuma" "$MAX_RETRIES" "$RETRY_INTERVAL"
 
     # The healthcheck passes a little before the Socket.IO endpoint answers.
     sleep 5


### PR DESCRIPTION
Closes #33.

## Requalifying the issue

The issue dates from when `scripts/lib.sh` only had basic utilities. Since then, most of what it asked for has already landed incrementally:
- `wait_for_service()` → `wait_for_container` / `wait_for_health` / `wait_for_http_endpoint` already exist in `lib.sh`;
- `configure_oidc_client()` → the shareable part (Authelia side) already exists (`get_oidc_secret`, `ensure_authelia_oidc_materials`); the rest cannot be factored out, since each app registers its client through a different mechanism (occ, PocketBase API, SQLite DB, appsettings…);
- `configure_smtp()` → only one script configures SMTP today (beszel/PocketBase), nothing to share;
- S3 → two usages with different shapes (backrest env reads vs PocketBase payload), no real duplication.

## What this PR does (the remaining deduplication)

- **`create_headscale_api_key()`**: duplicated verbatim in `headscale-init.sh` and `homepage-widgets-bootstrap.sh` → moved to `lib.sh`.
- **`compose()`**: duplicated in `open-webui-bootstrap.sh` and `rotate-password.sh` → moved to `lib.sh`, which now also uses it for its own inline `(cd "$PROJECT_DIR" && docker compose …)` calls.
- **`wait_for_kuma_health()`**: verbatim copy of `lib.sh`'s `wait_for_health` → removed.
- **`wait_for_cmd()`** (new): generic retry loop; the local `wait_for_{headscale,prowlarr,flaresolverr,qbittorrent,occ}` loops now build on it while keeping their own predicates and log messages.

## Latent bug fixed, found while testing

Running `headscale-init.sh` as non-root: the `config/headplane/headscale_api_key` file (root-owned, 600) being unreadable was treated as a missing key → the script minted an orphan Headscale API key, failed to write it, yet still logged "Stored …" (the calling `if !` context disables `set -e`). Fixed with a readability guard before minting and a checked write. The orphan key created during testing was expired (`headscale apikeys expire`).

## Deliberately out of scope

`backrest-post-hook.sh`, `backrest-unlock.sh` and `db-backup.sh` keep their local `log()`: they are mounted into the backrest container (`/hooks/`), where `lib.sh` does not exist.

## Tests

- `sh -n` on all scripts, `shellcheck -s sh` with no new warnings.
- Helpers unit-tested (`wait_for_cmd`, `compose`).
- Real idempotent runs on the Pi: `homepage-widgets-bootstrap`, `prowlarr-bootstrap`, `qbittorrent-bootstrap`, `headscale-init` (guard verified as non-root), `nextcloud-oidc-bootstrap` — all OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)