### PR TITLE
fix: stop Valkey OOM kills, silence invalid Pi-hole load check, make Unbound loggable

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -468,6 +468,11 @@ services:
       FTLCONF_misc_dnsmasq_lines: "address=/${HOST_NAME:-pi.lan}/${HOST_LAN_IP:-192.168.1.30}"
       FTLCONF_webserver_port: 8082
       FTLCONF_dns_domain_name: ${HOST_NAME:-pi.lan}
+      # FTL compares the *host-wide* 15min loadavg (/proc/loadavg is not
+      # namespaced) against the core count it can see, which `cpuset: "0-1"`
+      # below caps at 2. On this 4-core Pi that warns at ~50% utilisation, so
+      # the check is structurally wrong here. Host load is monitored by Beszel.
+      FTLCONF_misc_check_load: "false"
     volumes:
       - pihole_data:/etc/pihole
       - ./config/pihole/dnsmasq.d:/etc/dnsmasq.d

--- a/compose.yaml
+++ b/compose.yaml
@@ -1938,7 +1938,10 @@ services:
       - nextcloud
       - auth
     deploy: *cpu-request-small
-    mem_limit: 64m
+    # Shared by Immich, Nextcloud and Authelia. Peak dataset has been seen at
+    # ~44M; the limit must also cover the BGSAVE fork's copy-on-write pages, so
+    # keep it well above config/redis/valkey.conf's maxmemory (192mb).
+    mem_limit: 256m
     oom_score_adj: *oom-score-critical
 
 volumes:

--- a/config/redis/valkey.conf
+++ b/config/redis/valkey.conf
@@ -10,7 +10,11 @@ save 60 10000
 appendonly no
 
 # Memory management
-maxmemory 200mb
+# Must stay comfortably below the container's mem_limit (256m in compose.yaml):
+# Valkey only counts its own dataset, while the cgroup also charges the BGSAVE
+# fork's copy-on-write pages. A 200mb maxmemory under a 64m mem_limit is what
+# got this container OOM-killed mid-BGSAVE.
+maxmemory 192mb
 maxmemory-policy volatile-lru
 
 # Logging

--- a/config/unbound/unbound.conf
+++ b/config/unbound/unbound.conf
@@ -36,6 +36,14 @@ server:
   private-address: fd00::/8
   private-address: fe80::/10
 
+  # Log to the container's stdout so `docker logs pi-unbound` works. Unbound
+  # defaults to use-syslog: yes, but there is no syslog daemon in this image, so
+  # every line (including the TCP errors Pi-hole reports as CONNECTION_ERROR)
+  # was being discarded.
+  use-syslog: no
+  logfile: ""
+  log-time-ascii: yes
+
   # Keep resource usage modest for Raspberry Pi
   num-threads: 1
   # Pi-hole may briefly fan out multiple TCP upstream queries during startup or


### PR DESCRIPTION
Found while diagnosing warnings and errors across the stack's compose logs. All 37 containers were healthy and compose config was clean; these are the three issues that had real causes behind them.

## 1. Valkey was OOM-killed by the kernel (`fix(redis)`)

The one actual crash in 24h. `valkey.conf` asked for `maxmemory 200mb` while `compose.yaml` capped the container at `mem_limit: 64m` — so Valkey never evicted, and the cgroup killed it first:

```
valkey-server invoked oom-killer
memory: usage 65536kB, limit 65536kB, failcnt 11481
```

It died mid-BGSAVE with no SIGTERM at a 44.29M peak dataset — the cgroup also charges the fork's copy-on-write pages. Immich logged 8x `missing 'error' handler on this Redis client` as it dropped, and Authelia session state went with it.

`mem_limit` → `256m`, `maxmemory` → `192mb`. Each value now documents the other, since the failure mode is the two drifting apart.

## 2. Pi-hole's load check cannot be correct here (`fix(pihole)`)

`Long-term load (15min avg) larger than number of processors: 3.0 > 2`, persisted in FTL's diagnosis banner until dismissed.

`/proc/loadavg` is not namespaced, so FTL reads host-wide load across all 4 cores — but compares it against the core count it can see, which `cpuset: "0-1"` caps at 2. It warns at ~50% utilisation of a 4-core Pi.

Disabled via `FTLCONF_misc_check_load`, matching how the rest of Pi-hole's config is managed here, rather than dropping the deliberate cpuset pin. Beszel already monitors host load properly.

## 3. Unbound was logging into the void (`fix(unbound)`)

`docker logs pi-unbound` returned **zero lines over 24h**. Unbound defaults to `use-syslog: yes` and this image has no syslog daemon, so everything was discarded.

This one had a cost. Pi-hole reported 15 TCP failures against `172.30.53.53#5335` as a CONNECTION_ERROR, and the resolver-side evidence is simply gone. The obvious suspect was the TCP connection limit, but `incoming-num-tcp` is already 20 and only 15 connections failed — **so the cause of that burst remains unknown.** It hasn't recurred in 12h and resolution tests pass through both Unbound directly and Pi-hole. Now it would be diagnosable.

## Verification

Changes were applied and validated against the live stack before being committed here:

- `docker compose config -q` clean; `unbound-checkconf` reports no errors
- `pi-redis` healthy at 15 MiB / 256 MiB, `maxmemory 192M`, `restarts=0`, no new OOM kills in `dmesg`
- `pi-unbound` emitting logs for the first time; `example.com` and `github.com` resolve via Unbound directly and through Pi-hole
- All 37 containers healthy after recreating `redis`, `pihole`, `unbound`

## Not in this PR

Three fixes from the same session that live outside the repo:

- **Swap exhaustion** (2.0Gi/2.0Gi used, 0 free). `/sbin/dphys-swapfile` has a built-in `CONF_MAXSWAP=2048` that silently caps larger requests; raised both it and `CONF_SWAPSIZE` to 4096 in `/etc/dphys-swapfile`. Now 4.0Gi with 2.4Gi free. **Untracked by the repo** — `make install` applies `config/sysctl.d/pi-pcloud.conf` but nothing manages swap sizing, so a fresh Pi hits the same 2Gi wall.
- **Kapowarr rate-limit flood** — 15,435 `429` warnings in 24h (99% of all log volume) from a daily `Search All` sweep of getcomics.org. Set to weekly. Lives in Kapowarr's SQLite `task_intervals`; there is no UI or API for it (`/system/tasks/planning` is GET-only) and `interval: 0` is not a disable — the scheduler computes `next_run = current_time + interval`, so zero fires continuously.
- **~50 GB of Docker storage reclaimed** (261G → 211G used). Note that `docker volume prune` would have destroyed a superseded Nextcloud volume that `docker system df -v` reports as merely unused; it was checked for user data before removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)