### PR TITLE
feat(swap): manage host swap sizing from make install

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -21,6 +21,14 @@ SMTP_PASSWORD=
 # --- Data root for bind-mounted services ---
 DATA_LOCATION=./data
 
+# --- Host swap size in MB, applied by `make install` ---
+# Raspberry Pi OS ships 2048 MB and dphys-swapfile refuses to exceed its own
+# CONF_MAXSWAP=2048 default, so `make install` raises both. The model services
+# (parakeet, llama-cpp, immich-machine-learning) load weights, go idle and have
+# their cold pages evicted once, which fills a 2 GB swap in steady state and
+# leaves no room for the next spike. Leave empty to keep the default of 4096.
+SWAP_SIZE_MB=4096
+
 # --- Network Configuration ---
 HOST_LAN_IP=
 HOST_LAN_PARENT=eth0

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,8 @@ install: check-env
 	@echo "🧰 Applying host sysctl settings..."
 	sudo cp config/sysctl.d/pi-pcloud.conf /etc/sysctl.d/99-pi-pcloud.conf
 	sudo sysctl --system >/dev/null
+	@echo "💽 Sizing host swap..."
+	@./scripts/configure-swap.sh || echo "  ⚠ swap sizing skipped"
 	@echo "🌐 Adding local DNS overrides to /etc/hosts..."
 	@HOST_NAME_VAL=$$(grep -E '^HOST_NAME=' .env | tail -n1 | cut -d= -f2-); \
 	HOST_LAN_IP_VAL=$$(grep -E '^HOST_LAN_IP=' .env | tail -n1 | cut -d= -f2-); \
@@ -116,6 +118,13 @@ uninstall:
 	@echo "🧰 Removing host sysctl settings..."
 	-sudo rm -f /etc/sysctl.d/99-pi-pcloud.conf
 	-sudo sysctl --system >/dev/null
+	@echo "💽 Restoring original swap config..."
+	@if [ -f /etc/dphys-swapfile.pi-pcloud.bak ]; then \
+		sudo mv /etc/dphys-swapfile.pi-pcloud.bak /etc/dphys-swapfile; \
+		echo "  ✔ /etc/dphys-swapfile restored (applies on next reboot)"; \
+	else \
+		echo "  ℹ no backup found, leaving /etc/dphys-swapfile as is"; \
+	fi
 	@echo "🌐 Removing local DNS overrides from /etc/hosts..."
 	-sudo sed -i "/# pi-pcloud local overrides/,/# end pi-pcloud local overrides/d" /etc/hosts
 	@echo "🧹 Removing systemd units..."

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -372,11 +372,12 @@ counter.
 **Swap needs two conditions, and that is the interesting one.** It was written
 first as a plain `SWAP_PCT = 50` and fired on its first run against a box where
 nothing was wrong: 103 days of uptime, swap 100% full, **7G of RAM available, no
-OOM kill on record, and 0.13 MB/min of actual paging**. The 2G is
-`/var/swap` on the NVMe, and what filled it was `parakeet` (578M), `llama-cpp`
-(351M) and `immich-machine-learning` (158M) - services that load a model, go idle,
-and have their cold pages evicted exactly once. That is what swap is *for*, and
-the fill level cannot tell it apart from a machine fighting for RAM.
+OOM kill on record, and 0.13 MB/min of actual paging**. The 2G (the size at the
+time; see below) is `/var/swap` on the NVMe, and what filled it was `parakeet`
+(578M), `llama-cpp` (351M) and `immich-machine-learning` (158M) - services that
+load a model, go idle, and have their cold pages evicted exactly once. That is
+what swap is *for*, and the fill level cannot tell it apart from a machine
+fighting for RAM.
 
 So the finding now needs `SWAP_PCT` **and** `RAM_PRESSURE_PCT` (80%) together.
 `RAM_PRESSURE_PCT` sits below `MEMORY_PCT` on purpose: paging under pressure
@@ -384,6 +385,20 @@ starts before RAM is exhausted, so the swap finding can fire one step ahead of t
 memory one. The `memory` topic still reports swap unconditionally for anyone who
 wants the raw number. The general lesson for any threshold added here: a level is
 a state, and only some states are faults.
+
+**The size itself is now managed**, by `scripts/configure-swap.sh` from
+`make install`, with `SWAP_SIZE_MB` (default 4096) in `.env`. Not because a full
+swap is a fault - the paragraph above is still the right reading - but because
+2048 MB is *exactly* what those three model services evict in steady state, which
+leaves nothing for the next spike. Two settings are needed rather than one:
+`/sbin/dphys-swapfile` carries its own `CONF_MAXSWAP=2048` and silently clamps
+`CONF_SWAPSIZE` down to it, so raising only the latter appears to work and
+changes nothing.
+
+Resizing means `swapoff`, which pages everything back into RAM at once, so the
+script only restarts the service when available RAM covers the swapped-out set
+with 20% headroom, and otherwise leaves the new size to take effect on the next
+reboot.
 
 Nothing new is measured for it - it reuses the collectors the other topics already
 call, so the whole pass is one `statvfs` per filesystem, two `/proc` reads, one

--- a/scripts/configure-swap.sh
+++ b/scripts/configure-swap.sh
@@ -1,0 +1,155 @@
+#!/bin/sh
+# Configure the host swap file size via dphys-swapfile (Raspberry Pi OS).
+#
+# Two settings matter, and only setting the first one silently does nothing:
+# CONF_SWAPSIZE is the size we want, but /sbin/dphys-swapfile also carries its
+# own CONF_MAXSWAP=2048 default and clamps CONF_SWAPSIZE down to it -
+# "restricting to config limit". Any request above 2048 MB needs both raised.
+#
+# Applying a new size means swapoff, which pages every swapped-out anonymous
+# page back into RAM. On a box whose swap is full that is a multi-GB spike, so
+# the restart is guarded on available memory and otherwise deferred to reboot.
+#
+# Idempotent: re-runs are a no-op once the file and the live swap both match.
+# Best-effort by design - a host that cannot take a bigger swap file should not
+# fail `make install`.
+
+set -eu
+
+. "$(dirname "$0")/lib.sh"
+
+DPHYS_CONF="${DPHYS_CONF:-/etc/dphys-swapfile}"
+# Headroom multiplier over the swap we have to page back in before we dare
+# swapoff. 1.2 leaves 20% slack for whatever else allocates mid-restart.
+# Overridable so the guard can be exercised without a real resize.
+SAFETY_FACTOR_NUM="${SAFETY_FACTOR_NUM:-12}"
+SAFETY_FACTOR_DEN="${SAFETY_FACTOR_DEN:-10}"
+
+# --- Desired size -----------------------------------------------------------
+
+resolve_swap_size_mb() {
+    local size
+    size="$(get_env_value SWAP_SIZE_MB)"
+    [ -n "$size" ] || size=4096
+
+    case "$size" in
+        '' | *[!0-9]*)
+            die "SWAP_SIZE_MB must be a plain number of megabytes, got '$size'"
+            ;;
+    esac
+
+    if [ "$size" -lt 256 ]; then
+        die "SWAP_SIZE_MB=$size is too small to be deliberate (minimum 256)"
+    fi
+
+    printf '%s' "$size"
+}
+
+# --- /etc/dphys-swapfile edits ----------------------------------------------
+
+# Set KEY=VALUE whether the line is currently set, commented out, or absent.
+# dphys-swapfile ships CONF_MAXSWAP commented, so all three cases are real.
+set_conf_key() {
+    local key="$1"
+    local value="$2"
+    local file="$3"
+
+    if grep -qE "^[[:space:]]*#?[[:space:]]*${key}=" "$file"; then
+        sudo sed -i -E "s|^[[:space:]]*#?[[:space:]]*${key}=.*|${key}=${value}|" "$file"
+    else
+        printf '%s=%s\n' "$key" "$value" | sudo tee -a "$file" >/dev/null
+    fi
+}
+
+conf_value() {
+    # Last uncommented assignment wins, matching `.`-sourcing semantics.
+    grep -E "^[[:space:]]*$1=" "$2" 2>/dev/null | tail -n1 | cut -d= -f2- | tr -d '"'
+}
+
+# --- Live swap state --------------------------------------------------------
+
+active_swap_total_mb() {
+    awk '/^SwapTotal:/ {printf "%d", $2/1024}' /proc/meminfo 2>/dev/null || echo 0
+}
+
+active_swap_used_mb() {
+    awk '/^SwapTotal:/{t=$2} /^SwapFree:/{f=$2} END {printf "%d", (t-f)/1024}' \
+        /proc/meminfo 2>/dev/null || echo 0
+}
+
+mem_available_mb() {
+    awk '/^MemAvailable:/ {printf "%d", $2/1024}' /proc/meminfo 2>/dev/null || echo 0
+}
+
+# Whether we can afford to swapoff right now: everything currently in swap has
+# to fit in available RAM, with headroom.
+restart_is_safe() {
+    local used avail needed
+    used="$(active_swap_used_mb)"
+    avail="$(mem_available_mb)"
+    needed=$(( used * SAFETY_FACTOR_NUM / SAFETY_FACTOR_DEN ))
+
+    if [ "$avail" -ge "$needed" ]; then
+        return 0
+    fi
+
+    log "WARNING: not restarting dphys-swapfile now - ${used}MB is swapped out"
+    log "         and only ${avail}MB RAM is available (need ~${needed}MB to"
+    log "         page it back in). The new size applies on the next reboot."
+    return 1
+}
+
+main() {
+    if [ ! -f "$DPHYS_CONF" ]; then
+        log "No $DPHYS_CONF (dphys-swapfile not installed); skipping swap sizing"
+        return 0
+    fi
+
+    local desired current_size current_max active
+    desired="$(resolve_swap_size_mb)"
+    current_size="$(conf_value CONF_SWAPSIZE "$DPHYS_CONF")"
+    current_max="$(conf_value CONF_MAXSWAP "$DPHYS_CONF")"
+    active="$(active_swap_total_mb)"
+
+    # Allow a little slop: dphys rounds, and /proc/meminfo reports slightly
+    # less than the file size because of swap header pages.
+    if [ "$current_size" = "$desired" ] && [ "$current_max" = "$desired" ] &&
+        [ "$active" -ge $(( desired - 16 )) ]; then
+        log "Swap already ${active}MB with CONF_SWAPSIZE/CONF_MAXSWAP=$desired; nothing to do"
+        return 0
+    fi
+
+    if [ ! -f "$DPHYS_CONF.pi-pcloud.bak" ]; then
+        sudo cp "$DPHYS_CONF" "$DPHYS_CONF.pi-pcloud.bak"
+        log "Backed up original to $DPHYS_CONF.pi-pcloud.bak"
+    fi
+
+    set_conf_key CONF_SWAPSIZE "$desired" "$DPHYS_CONF"
+    set_conf_key CONF_MAXSWAP "$desired" "$DPHYS_CONF"
+    log "Set CONF_SWAPSIZE=$desired and CONF_MAXSWAP=$desired in $DPHYS_CONF"
+
+    if [ "$active" -ge $(( desired - 16 )) ]; then
+        log "Live swap is already ${active}MB; no restart needed"
+        return 0
+    fi
+
+    if ! restart_is_safe; then
+        return 0
+    fi
+
+    log "Resizing swap ${active}MB -> ${desired}MB (swapoff/swapon)..."
+    if ! sudo systemctl restart dphys-swapfile; then
+        log "WARNING: dphys-swapfile restart failed; new size applies on reboot"
+        return 0
+    fi
+
+    active="$(active_swap_total_mb)"
+    if [ "$active" -ge $(( desired - 16 )) ]; then
+        log "Swap is now ${active}MB"
+    else
+        log "WARNING: swap is ${active}MB, expected ~${desired}MB - check"
+        log "         'systemctl status dphys-swapfile' and free space on /var"
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
Closes the last untracked host setting from the diagnosis session behind #224. `make install` already applies `config/sysctl.d/pi-pcloud.conf` (including `vm.swappiness = 10`), but nothing managed the swap **size** — so a fresh Pi stayed at Raspberry Pi OS's 2048 MB.

## Why 2048 MB is the wrong size for this stack

`docs/CONFIGURATION.md` already documents the measurement: `parakeet` (578M), `llama-cpp` (351M) and `immich-machine-learning` (158M) load their weights, go idle, and have their cold pages evicted exactly once. That is ~1.1 GB of permanently-resident swap in steady state.

To be clear about what is and isn't a fault here: **a full swap is not itself a problem** — that doc's reasoning (which is why the `anomalies` check requires `SWAP_PCT` *and* `RAM_PRESSURE_PCT` together) is correct and unchanged. The problem is that 2048 MB is *approximately exactly* what those services evict, so the swap sits at 100% with **zero headroom** for the next spike. On the box this was found on: `2.0Gi total / 2.0Gi used / 0 free`.

## The trap: it takes two settings, not one

`/sbin/dphys-swapfile` carries its own `CONF_MAXSWAP=2048` and clamps `CONF_SWAPSIZE` down to it:

```sh
if [ "${CONF_SWAPSIZE}" -gt "${CONF_MAXSWAP}" ] ; then
  echo -n ", restricting to config limit: ${CONF_MAXSWAP}MBytes"
```

So setting `CONF_SWAPSIZE=4096` alone *appears* to work and changes nothing. `scripts/configure-swap.sh` sets both, driven by `SWAP_SIZE_MB` (default 4096).

## Resizing must not be the thing that causes an OOM

Applying a new size means `swapoff`, which pages the **entire** swapped-out set back into RAM at once — multi-GB on a box whose swap is full. Given that the session this came from was triggered by an OOM kill, the script refuses to make that worse: it restarts `dphys-swapfile` only when available RAM covers the swapped-out set with 20% headroom, and otherwise writes the config and defers to the next reboot.

## Design notes

- **Idempotent and surgical.** The two keys are set whether currently assigned, commented out (`CONF_MAXSWAP` ships commented), or absent entirely. The rest of the file is preserved rather than replaced, since `/etc/dphys-swapfile` is a package conffile.
- **Best-effort.** A missing `/etc/dphys-swapfile` is a clean skip with exit 0, so non-Pi hosts still `make install`. The Makefile also guards with `|| echo "⚠ swap sizing skipped"`.
- **Reversible.** The original is backed up once to `/etc/dphys-swapfile.pi-pcloud.bak`; `make uninstall` restores it. Uninstall deliberately does *not* restart the service — a `swapoff` during teardown is risk for no benefit.
- **`local` / `SC3043`** matches `lib.sh` and every existing script; `shellcheck -s sh` reports the same two codes (`SC1091`, `SC3043`) as `scripts/kapowarr-pre-start.sh`, so no new lint debt. `dash -n` and `sh -n` clean.

## Verification

Run against the live host and against fixtures for the paths the host can't exercise:

| Case | Result |
|---|---|
| Already correct (live host, 4096) | no-op, exit 0, file untouched |
| Re-run (idempotency) | no-op |
| Pristine Pi OS defaults (`2048` + commented `CONF_MAXSWAP`) | both set to 4096, comments preserved, backup made |
| Keys absent entirely | both appended |
| Non-numeric `SWAP_SIZE_MB=4G` | dies exit 1, **file untouched** |
| `SWAP_SIZE_MB=64` (too small) | dies exit 1, file untouched |
| Missing `/etc/dphys-swapfile` | clean skip, exit 0 |
| Insufficient RAM headroom | refuses restart, writes config, defers to reboot, exit 0 |

The host itself was already migrated to 4096 manually during the diagnosis session, so this PR makes that state reproducible rather than changing it:

```
before:  2.0Gi total / 2.0Gi used / 0 free
after:   4.0Gi total / 3.1Gi used / 0.9Gi free
```

(That the larger swap is also filling is the expected, documented behaviour — 6.3 GB RAM remains available.)

## Note for #19

`install.sh` is not on `main` yet, so it is untouched here. When that branch lands, its privilege message ("`make install` applies sysctl, /etc/hosts and systemd changes") will be slightly incomplete — swap sizing is now a fourth thing, and it needs `sudo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)