### PR TITLE
feat: per-service enable/disable via Compose profiles

### DIFF
--- a/.agents/skills/add-service/SKILL.md
+++ b/.agents/skills/add-service/SKILL.md
@@ -95,6 +95,11 @@ Add `homepage.group` / `name` / `icon` / `href` / `description` labels, plus a
 `homepage.widget.*` block when a widget exists for the service — API keys are wired
 by `scripts/homepage-widgets-bootstrap.sh`.
 
+`homepage.group` doubles as the section the service is listed under in
+`make config`. If the service is pointless on its own (an addon, a worker, a
+sidecar), also add `pi-pcloud.companion-of=<service>` so the picker nests it
+under the one it belongs to and toggles the two together.
+
 ## 10. First-run setup
 
 Do it in `scripts/<service>-bootstrap.sh` (or `-pre-start.sh`), sourcing

--- a/.agents/skills/add-service/SKILL.md
+++ b/.agents/skills/add-service/SKILL.md
@@ -96,9 +96,12 @@ Add `homepage.group` / `name` / `icon` / `href` / `description` labels, plus a
 by `scripts/homepage-widgets-bootstrap.sh`.
 
 `homepage.group` doubles as the section the service is listed under in
-`make config`. If the service is pointless on its own (an addon, a worker, a
-sidecar), also add `pi-pcloud.companion-of=<service>` so the picker nests it
-under the one it belongs to and toggles the two together.
+`make config`, and `homepage.description` is the line shown beside it there. If
+the service is pointless on its own (an addon, a worker, a sidecar), also add
+`pi-pcloud.companion-of=<service>` so the picker nests it under the one it
+belongs to and toggles the two together — and still give it a description: a
+`homepage.*` label without `homepage.group` is discovered but never rendered,
+so it stays off the dashboard.
 
 ## 10. First-run setup
 

--- a/.env.dist
+++ b/.env.dist
@@ -21,6 +21,16 @@ SMTP_PASSWORD=
 # --- Data root for bind-mounted services ---
 DATA_LOCATION=./data
 
+# --- Services ---
+# Services to enable (comma-separated Docker Compose profiles; one profile per
+# optional service, named after it). "all" enables everything. Some services
+# auto-start their dependencies: qbittorrent/stremio/kapowarr pull in gluetun,
+# n8n-runners pulls in n8n, beszel-agent pulls in beszel, prowlarr pulls in
+# flaresolverr. Core infrastructure (traefik, authelia, pihole, headscale,
+# postgres, ...) always runs.
+# Example: COMPOSE_PROFILES=immich-server,nextcloud,stremio,open-webui,llama-cpp
+COMPOSE_PROFILES=all
+
 # --- Network Configuration ---
 HOST_LAN_IP=
 HOST_LAN_PARENT=eth0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
         run: |
           set -euo pipefail
           docker compose -f compose.yaml config >/dev/null
+          # Validate with every per-service profile enabled too, so optional
+          # services' definitions are checked even though they carry profiles.
+          COMPOSE_PROFILES=all docker compose -f compose.yaml config >/dev/null
           docker compose -f compose.yaml -f compose.test.yaml config >/dev/null
 
       - name: Lint workflow and Compose YAML
@@ -53,6 +56,17 @@ jobs:
       CLOUDFLARE_ZONE_ID: ci-zone-placeholder
       CLOUDFLARE_DNS_API_TOKEN: ci-token-placeholder
       COMPOSE_FILE: compose.yaml:compose.test.yaml
+      # Explicit list, NOT "all": profile lists merge across compose files, and
+      # compose.test.yaml marks CI-unfriendly services (gluetun, headscale,
+      # backrest, ...) with the ci-excluded profile — "all" would re-enable
+      # them. This list is every optional service except those and except
+      # services depending on them (headplane needs headscale; the gluetun
+      # tenants qbittorrent/stremio/kapowarr are out with gluetun), and
+      # reproduces exactly the service set CI started before profiles existed.
+      COMPOSE_PROFILES: >-
+        beszel,uptime-kuma,dockhand,n8n,n8n-runners,immich-machine-learning,
+        immich-server,nextcloud,comet,prowlarr,flaresolverr,kavita,
+        vaultwarden,system-tools,open-webui
       COMPOSE_ANSI: never
       COMPOSE_REMOVE_ORPHANS: "1"
       COMPOSE_PROGRESS: quiet

--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,10 @@
 !/config/homepage/secrets/README.md
 /config/homepage/homepage.env
 
+# Bytecode from importing the Python scripts (test harnesses, py_compile);
+# a plain run never writes it, since __main__ is not cached.
+__pycache__/
+*.pyc
+
 ._.DS_Store
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install uninstall start stop restart status logs doctor preflight check-env headscale-register headscale-reset rotate-password rotate-password-full
+.PHONY: help install uninstall start stop restart status logs doctor preflight check-env services enable disable headscale-register headscale-reset rotate-password rotate-password-full
 
 REQUIRED_ENV_VARS := HOST_NAME TIMEZONE EMAIL ADMIN_USER PASSWORD HOST_LAN_IP CLOUDFLARE_DNS_API_TOKEN CLOUDFLARE_ZONE_ID
 
@@ -23,6 +23,9 @@ help:
 	@echo "  restart          Restart stack"
 	@echo "  status           Show systemd status"
 	@echo "  logs             Follow compose logs"
+	@echo "  services         List optional services and whether each is enabled"
+	@echo "  enable s=<name>  Enable an optional service (updates COMPOSE_PROFILES, starts it)"
+	@echo "  disable s=<name> Disable an optional service (updates COMPOSE_PROFILES, stops it)"
 	@echo "  doctor           Report anything outside its threshold (disk, RAM, temp, containers, backups)"
 	@echo "  preflight        Quick env readiness check"
 	@echo "  headscale-register <key> Register a headscale node"
@@ -70,7 +73,8 @@ install: check-env
 	sudo cp /tmp/$(UNIT) /etc/systemd/system/
 	sed 's|__PROJECT_PATH__|$(PROJECT_PATH)|g' config/systemd/system/$(WATCH_UNIT) > /tmp/$(WATCH_UNIT)
 	sudo cp /tmp/$(WATCH_UNIT) /etc/systemd/system/
-	sudo cp config/systemd/system/nextcloud-cron.service /etc/systemd/system/
+	sed 's|__PROJECT_PATH__|$(PROJECT_PATH)|g' config/systemd/system/nextcloud-cron.service > /tmp/nextcloud-cron.service
+	sudo cp /tmp/nextcloud-cron.service /etc/systemd/system/
 	sudo cp config/systemd/system/nextcloud-cron.timer /etc/systemd/system/
 	sudo systemctl daemon-reload
 	sudo systemctl enable $(UNIT) $(WATCH_UNIT) nextcloud-cron.timer
@@ -156,6 +160,106 @@ status:
 logs:
 	@echo "📝 Logs (Ctrl+C to exit)"
 	$(COMPOSE) logs -f --tail=100
+
+# Optional services are toggled through Docker Compose profiles: every optional
+# service carries a profile named after itself (plus the catch-all "all"), and
+# COMPOSE_PROFILES in .env selects which run. A missing line means everything
+# (pre-profiles installs); an explicitly empty value means core-only, matching
+# what docker compose does with it. Enabled-ness is computed with `docker
+# compose config --services` under the current selection, which is
+# authoritative and handles coupled profiles (e.g. stremio auto-enabling
+# gluetun) for free.
+services:
+	@if [ ! -f .env ]; then echo "❌ .env missing (copy .env.dist)"; exit 1; fi
+	@if grep -qE '^COMPOSE_PROFILES=' .env; then \
+		profiles=$$(grep -E '^COMPOSE_PROFILES=' .env | tail -n1 | cut -d= -f2-); \
+		echo "🧩 Optional services (COMPOSE_PROFILES=$${profiles:-<empty: core only>})"; \
+	else \
+		profiles=all; \
+		echo "🧩 Optional services (no COMPOSE_PROFILES line in .env = all)"; \
+	fi; \
+	known=$$($(COMPOSE) config --profiles | grep -v '^all$$' | sort) || exit 1; \
+	enabled=$$(COMPOSE_PROFILES="$$profiles" $(COMPOSE) config --services); \
+	for svc in $$known; do \
+		if printf '%s\n' "$$enabled" | grep -qx "$$svc"; then \
+			printf '  ✅ %s enabled\n' "$$svc"; \
+		else \
+			printf '  ⛔ %s disabled\n' "$$svc"; \
+		fi; \
+	done
+
+enable:
+	@if [ ! -f .env ]; then echo "❌ .env missing (copy .env.dist)"; exit 1; fi
+	@if [ -z "$(s)" ]; then \
+		echo "❌ Usage: make enable s=<service>. Valid services:"; \
+		$(COMPOSE) config --profiles | grep -v '^all$$' | sort | sed 's/^/  - /'; \
+		exit 1; \
+	fi
+	@if ! $(COMPOSE) config --profiles | grep -v '^all$$' | grep -qx "$(s)"; then \
+		echo "❌ Unknown service '$(s)'. Valid services:"; \
+		$(COMPOSE) config --profiles | grep -v '^all$$' | sort | sed 's/^/  - /'; \
+		exit 1; \
+	fi
+	@if grep -qE '^COMPOSE_PROFILES=' .env; then \
+		current=$$(grep -E '^COMPOSE_PROFILES=' .env | tail -n1 | cut -d= -f2-); \
+	else \
+		echo "ℹ️  No COMPOSE_PROFILES line in .env (= everything enabled): writing the full explicit list first"; \
+		current=$$($(COMPOSE) config --profiles | grep -v '^all$$' | paste -sd, -); \
+	fi; \
+	if [ "$$current" = "all" ]; then \
+		echo "ℹ️  COMPOSE_PROFILES=all: every service is already enabled"; \
+	else \
+		case ",$$current," in \
+			",,") new="$(s)";; \
+			*",$(s),"*) new="$$current"; echo "ℹ️  $(s) already in COMPOSE_PROFILES";; \
+			*) new="$$current,$(s)";; \
+		esac; \
+		if grep -qE '^COMPOSE_PROFILES=' .env; then \
+			sed -i "s/^COMPOSE_PROFILES=.*/COMPOSE_PROFILES=$$new/" .env; \
+		else \
+			printf 'COMPOSE_PROFILES=%s\n' "$$new" >> .env; \
+		fi; \
+		echo "✏️  COMPOSE_PROFILES=$$new"; \
+	fi
+	@echo "🚀 Starting $(s) (and any services it depends on)..."
+	@$(COMPOSE) up -d $(s)
+	@echo "✅ $(s) enabled — run 'make restart' to keep the systemd-managed stack consistent"
+
+disable:
+	@if [ ! -f .env ]; then echo "❌ .env missing (copy .env.dist)"; exit 1; fi
+	@if [ -z "$(s)" ]; then \
+		echo "❌ Usage: make disable s=<service>. Valid services:"; \
+		$(COMPOSE) config --profiles | grep -v '^all$$' | sort | sed 's/^/  - /'; \
+		exit 1; \
+	fi
+	@if ! $(COMPOSE) config --profiles | grep -v '^all$$' | grep -qx "$(s)"; then \
+		echo "❌ Unknown service '$(s)'. Valid services:"; \
+		$(COMPOSE) config --profiles | grep -v '^all$$' | sort | sed 's/^/  - /'; \
+		exit 1; \
+	fi
+	@if grep -qE '^COMPOSE_PROFILES=' .env; then \
+		current=$$(grep -E '^COMPOSE_PROFILES=' .env | tail -n1 | cut -d= -f2-); \
+	else \
+		current=all; \
+	fi; \
+	if [ "$$current" = "all" ]; then \
+		echo "ℹ️  COMPOSE_PROFILES was '$$current' (= everything enabled): writing the full explicit list first"; \
+		current=$$($(COMPOSE) config --profiles | grep -v '^all$$' | paste -sd, -); \
+	fi; \
+	new=$$(printf '%s\n' "$$current" | tr ',' '\n' | grep -vx "$(s)" | paste -sd, - || true); \
+	[ -n "$$new" ] || echo "⚠️  COMPOSE_PROFILES is now empty: only core services will run"; \
+	if grep -qE '^COMPOSE_PROFILES=' .env; then \
+		sed -i "s/^COMPOSE_PROFILES=.*/COMPOSE_PROFILES=$$new/" .env; \
+	else \
+		printf 'COMPOSE_PROFILES=%s\n' "$$new" >> .env; \
+	fi; \
+	echo "✏️  COMPOSE_PROFILES=$$new"; \
+	if COMPOSE_PROFILES="$$new" $(COMPOSE) config --services 2>/dev/null | grep -qx "$(s)"; then \
+		echo "⚠️  $(s) is still auto-enabled by another enabled service's profile — it will come back on 'make restart'"; \
+	fi
+	@echo "🛑 Stopping and removing $(s)..."
+	@$(COMPOSE) stop $(s) && $(COMPOSE) rm -f $(s)
+	@echo "✅ $(s) disabled — run 'make restart' to keep the systemd-managed stack consistent"
 
 # The same endpoint the assistant calls for the `anomalies` topic, so the shell
 # and the chat cannot disagree. Asked from inside the container because

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install uninstall start stop restart status logs doctor preflight check-env services enable disable headscale-register headscale-reset rotate-password rotate-password-full
+.PHONY: help install uninstall start stop restart status logs doctor preflight check-env services enable disable config headscale-register headscale-reset rotate-password rotate-password-full
 
 REQUIRED_ENV_VARS := HOST_NAME TIMEZONE EMAIL ADMIN_USER PASSWORD HOST_LAN_IP CLOUDFLARE_DNS_API_TOKEN CLOUDFLARE_ZONE_ID
 
@@ -24,8 +24,9 @@ help:
 	@echo "  status           Show systemd status"
 	@echo "  logs             Follow compose logs"
 	@echo "  services         List optional services and whether each is enabled"
-	@echo "  enable s=<name>  Enable an optional service (updates COMPOSE_PROFILES, starts it)"
+	@echo "  enable s=<name>  Enable an optional service (updates COMPOSE_PROFILES, starts it, runs its init hooks)"
 	@echo "  disable s=<name> Disable an optional service (updates COMPOSE_PROFILES, stops it)"
+	@echo "  config           Interactive checklist to choose which services run"
 	@echo "  doctor           Report anything outside its threshold (disk, RAM, temp, containers, backups)"
 	@echo "  preflight        Quick env readiness check"
 	@echo "  headscale-register <key> Register a headscale node"
@@ -163,103 +164,21 @@ logs:
 
 # Optional services are toggled through Docker Compose profiles: every optional
 # service carries a profile named after itself (plus the catch-all "all"), and
-# COMPOSE_PROFILES in .env selects which run. A missing line means everything
-# (pre-profiles installs); an explicitly empty value means core-only, matching
-# what docker compose does with it. Enabled-ness is computed with `docker
-# compose config --services` under the current selection, which is
-# authoritative and handles coupled profiles (e.g. stremio auto-enabling
-# gluetun) for free.
+# COMPOSE_PROFILES in .env selects which run. All the logic (enabled-ness
+# computation, .env rewriting, the per-service pre-start/bootstrap hooks and
+# the interactive checklist) lives in scripts/services.sh — these targets are
+# thin wrappers around it.
 services:
-	@if [ ! -f .env ]; then echo "❌ .env missing (copy .env.dist)"; exit 1; fi
-	@if grep -qE '^COMPOSE_PROFILES=' .env; then \
-		profiles=$$(grep -E '^COMPOSE_PROFILES=' .env | tail -n1 | cut -d= -f2-); \
-		echo "🧩 Optional services (COMPOSE_PROFILES=$${profiles:-<empty: core only>})"; \
-	else \
-		profiles=all; \
-		echo "🧩 Optional services (no COMPOSE_PROFILES line in .env = all)"; \
-	fi; \
-	known=$$($(COMPOSE) config --profiles | grep -v '^all$$' | sort) || exit 1; \
-	enabled=$$(COMPOSE_PROFILES="$$profiles" $(COMPOSE) config --services); \
-	for svc in $$known; do \
-		if printf '%s\n' "$$enabled" | grep -qx "$$svc"; then \
-			printf '  ✅ %s enabled\n' "$$svc"; \
-		else \
-			printf '  ⛔ %s disabled\n' "$$svc"; \
-		fi; \
-	done
+	@/bin/sh scripts/services.sh list
 
 enable:
-	@if [ ! -f .env ]; then echo "❌ .env missing (copy .env.dist)"; exit 1; fi
-	@if [ -z "$(s)" ]; then \
-		echo "❌ Usage: make enable s=<service>. Valid services:"; \
-		$(COMPOSE) config --profiles | grep -v '^all$$' | sort | sed 's/^/  - /'; \
-		exit 1; \
-	fi
-	@if ! $(COMPOSE) config --profiles | grep -v '^all$$' | grep -qx "$(s)"; then \
-		echo "❌ Unknown service '$(s)'. Valid services:"; \
-		$(COMPOSE) config --profiles | grep -v '^all$$' | sort | sed 's/^/  - /'; \
-		exit 1; \
-	fi
-	@if grep -qE '^COMPOSE_PROFILES=' .env; then \
-		current=$$(grep -E '^COMPOSE_PROFILES=' .env | tail -n1 | cut -d= -f2-); \
-	else \
-		echo "ℹ️  No COMPOSE_PROFILES line in .env (= everything enabled): writing the full explicit list first"; \
-		current=$$($(COMPOSE) config --profiles | grep -v '^all$$' | paste -sd, -); \
-	fi; \
-	if [ "$$current" = "all" ]; then \
-		echo "ℹ️  COMPOSE_PROFILES=all: every service is already enabled"; \
-	else \
-		case ",$$current," in \
-			",,") new="$(s)";; \
-			*",$(s),"*) new="$$current"; echo "ℹ️  $(s) already in COMPOSE_PROFILES";; \
-			*) new="$$current,$(s)";; \
-		esac; \
-		if grep -qE '^COMPOSE_PROFILES=' .env; then \
-			sed -i "s/^COMPOSE_PROFILES=.*/COMPOSE_PROFILES=$$new/" .env; \
-		else \
-			printf 'COMPOSE_PROFILES=%s\n' "$$new" >> .env; \
-		fi; \
-		echo "✏️  COMPOSE_PROFILES=$$new"; \
-	fi
-	@echo "🚀 Starting $(s) (and any services it depends on)..."
-	@$(COMPOSE) up -d $(s)
-	@echo "✅ $(s) enabled — run 'make restart' to keep the systemd-managed stack consistent"
+	@/bin/sh scripts/services.sh enable "$(s)"
 
 disable:
-	@if [ ! -f .env ]; then echo "❌ .env missing (copy .env.dist)"; exit 1; fi
-	@if [ -z "$(s)" ]; then \
-		echo "❌ Usage: make disable s=<service>. Valid services:"; \
-		$(COMPOSE) config --profiles | grep -v '^all$$' | sort | sed 's/^/  - /'; \
-		exit 1; \
-	fi
-	@if ! $(COMPOSE) config --profiles | grep -v '^all$$' | grep -qx "$(s)"; then \
-		echo "❌ Unknown service '$(s)'. Valid services:"; \
-		$(COMPOSE) config --profiles | grep -v '^all$$' | sort | sed 's/^/  - /'; \
-		exit 1; \
-	fi
-	@if grep -qE '^COMPOSE_PROFILES=' .env; then \
-		current=$$(grep -E '^COMPOSE_PROFILES=' .env | tail -n1 | cut -d= -f2-); \
-	else \
-		current=all; \
-	fi; \
-	if [ "$$current" = "all" ]; then \
-		echo "ℹ️  COMPOSE_PROFILES was '$$current' (= everything enabled): writing the full explicit list first"; \
-		current=$$($(COMPOSE) config --profiles | grep -v '^all$$' | paste -sd, -); \
-	fi; \
-	new=$$(printf '%s\n' "$$current" | tr ',' '\n' | grep -vx "$(s)" | paste -sd, - || true); \
-	[ -n "$$new" ] || echo "⚠️  COMPOSE_PROFILES is now empty: only core services will run"; \
-	if grep -qE '^COMPOSE_PROFILES=' .env; then \
-		sed -i "s/^COMPOSE_PROFILES=.*/COMPOSE_PROFILES=$$new/" .env; \
-	else \
-		printf 'COMPOSE_PROFILES=%s\n' "$$new" >> .env; \
-	fi; \
-	echo "✏️  COMPOSE_PROFILES=$$new"; \
-	if COMPOSE_PROFILES="$$new" $(COMPOSE) config --services 2>/dev/null | grep -qx "$(s)"; then \
-		echo "⚠️  $(s) is still auto-enabled by another enabled service's profile — it will come back on 'make restart'"; \
-	fi
-	@echo "🛑 Stopping and removing $(s)..."
-	@$(COMPOSE) stop $(s) && $(COMPOSE) rm -f $(s)
-	@echo "✅ $(s) disabled — run 'make restart' to keep the systemd-managed stack consistent"
+	@/bin/sh scripts/services.sh disable "$(s)"
+
+config:
+	@/bin/sh scripts/services.sh config
 
 # The same endpoint the assistant calls for the `anomalies` topic, so the shell
 # and the chat cannot disagree. Asked from inside the container because

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ If you're deciding between approaches, here's the short version:
 | **Monitoring & Backup** | Beszel (metrics & alerts), Uptime Kuma (uptime checks), Homepage (dashboard), Backrest (restic backups), Dockhand (container management) |
 | **Infrastructure** | PostgreSQL, Redis (Valkey), ddns-updater |
 
+You don't have to run all of it: core infrastructure always starts, and every other service can be switched on or off per-install with `make enable` / `make disable` (Docker Compose profiles) — see [Choosing which services run](docs/CONFIGURATION.md#choosing-which-services-run).
+
 ## Requirements
 
 **Hardware:**

--- a/compose.yaml
+++ b/compose.yaml
@@ -325,6 +325,8 @@ services:
     image: pi-beszel-agent:local
     container_name: pi-beszel-agent
     profiles: ["beszel-agent", "all"]
+    labels:
+      - "pi-pcloud.companion-of=beszel"
     depends_on:
       beszel:
         condition: service_healthy
@@ -575,6 +577,8 @@ services:
     image: n8nio/runners:2.35.3
     container_name: pi-n8n-runners
     profiles: ["n8n-runners", "all"]
+    labels:
+      - "pi-pcloud.companion-of=n8n"
     environment:
       - N8N_RUNNERS_TASK_BROKER_URI=http://n8n:5679
       - N8N_RUNNERS_AUTH_TOKEN=${N8N_RUNNERS_AUTH_TOKEN:-n8n-runner-secret}
@@ -756,6 +760,8 @@ services:
     <<: *service-defaults
     container_name: pi-immich-machine-learning
     profiles: ["immich-machine-learning", "all"]
+    labels:
+      - "pi-pcloud.companion-of=immich-server"
     image: ghcr.io/immich-app/immich-machine-learning:v3.1.0
     networks:
       - dns_egress
@@ -1178,6 +1184,7 @@ services:
       - comet_data:/data
     labels:
       - "homepage.group=Video"
+      - "pi-pcloud.companion-of=stremio"
       - "homepage.name=Comet"
       - "homepage.href=https://comet.${HOST_NAME:-pi.lan}"
       - "homepage.description=Stremio debrid addon"
@@ -1295,6 +1302,8 @@ services:
     image: ghcr.io/flaresolverr/flaresolverr:v3.5.0
     container_name: pi-flaresolverr
     profiles: ["flaresolverr", "prowlarr", "all"]
+    labels:
+      - "pi-pcloud.companion-of=prowlarr"
     networks:
       - frontend
     dns:

--- a/compose.yaml
+++ b/compose.yaml
@@ -157,8 +157,10 @@ services:
     depends_on:
       immich-server:
         condition: service_healthy
+        required: false
       nextcloud:
         condition: service_healthy
+        required: false
       postgres:
         condition: service_healthy
       authelia:
@@ -273,6 +275,7 @@ services:
     <<: *service-defaults
     image: henrygd/beszel:0.18.7
     container_name: pi-beszel
+    profiles: ["beszel", "beszel-agent", "all"]
     networks:
       - frontend
     expose:
@@ -321,6 +324,7 @@ services:
       dockerfile: Dockerfile
     image: pi-beszel-agent:local
     container_name: pi-beszel-agent
+    profiles: ["beszel-agent", "all"]
     depends_on:
       beszel:
         condition: service_healthy
@@ -355,6 +359,7 @@ services:
     <<: *service-defaults
     image: louislam/uptime-kuma:2
     container_name: pi-uptime-kuma
+    profiles: ["uptime-kuma", "all"]
     networks:
       - frontend
       - ntfy
@@ -394,6 +399,7 @@ services:
     <<: *service-defaults
     image: fnsys/dockhand:v1.0.42
     container_name: pi-dockhand
+    profiles: ["dockhand", "all"]
     networks:
       - frontend
     expose:
@@ -510,6 +516,7 @@ services:
     <<: *service-defaults
     image: n8nio/n8n:2.35.3
     container_name: pi-n8n
+    profiles: ["n8n", "n8n-runners", "all"]
     expose:
       - 5678
     labels:
@@ -567,6 +574,7 @@ services:
     <<: *service-defaults
     image: n8nio/runners:2.35.3
     container_name: pi-n8n-runners
+    profiles: ["n8n-runners", "all"]
     environment:
       - N8N_RUNNERS_TASK_BROKER_URI=http://n8n:5679
       - N8N_RUNNERS_AUTH_TOKEN=${N8N_RUNNERS_AUTH_TOKEN:-n8n-runner-secret}
@@ -587,6 +595,7 @@ services:
     <<: *service-defaults
     image: ghcr.io/tale/headplane:0.7.0
     container_name: pi-headplane
+    profiles: ["headplane", "all"]
     networks:
       - frontend
     extra_hosts:
@@ -746,6 +755,7 @@ services:
   immich-machine-learning:
     <<: *service-defaults
     container_name: pi-immich-machine-learning
+    profiles: ["immich-machine-learning", "all"]
     image: ghcr.io/immich-app/immich-machine-learning:v3.1.0
     networks:
       - dns_egress
@@ -770,6 +780,7 @@ services:
   immich-server:
     <<: *service-defaults
     container_name: pi-immich
+    profiles: ["immich-server", "all"]
     image: ghcr.io/immich-app/immich-server:v3.1.0
     volumes:
       - ${DATA_LOCATION:-./data}/immich:/data
@@ -826,6 +837,7 @@ services:
     <<: *service-defaults
     image: nextcloud:34.0.3-apache
     container_name: pi-nextcloud
+    profiles: ["nextcloud", "all"]
     environment:
       - NEXTCLOUD_ADMIN_USER=${ADMIN_USER:-admin}
       - NEXTCLOUD_ADMIN_PASSWORD=${PASSWORD}
@@ -978,6 +990,7 @@ services:
     <<: *service-defaults
     image: qmcgaw/gluetun:v3
     container_name: pi-gluetun
+    profiles: ["gluetun", "qbittorrent", "stremio", "kapowarr", "all"]
     cap_add:
       - NET_ADMIN
     devices:
@@ -1059,6 +1072,7 @@ services:
     <<: *service-defaults
     image: lscr.io/linuxserver/qbittorrent:latest
     container_name: pi-qbittorrent
+    profiles: ["qbittorrent", "all"]
     network_mode: "service:gluetun"
     depends_on:
       gluetun:
@@ -1103,6 +1117,7 @@ services:
     <<: *service-defaults
     image: stremio/server:v4.21.0
     container_name: pi-stremio
+    profiles: ["stremio", "all"]
     network_mode: "service:gluetun"
     depends_on:
       gluetun:
@@ -1132,6 +1147,7 @@ services:
     # No semver image tags are published; pin latest (currently v2.54.1) by digest.
     image: ghcr.io/g0ldyy/comet:latest@sha256:dca62133336e02784d02aaad861381820674d1c8e3e98a03797610b81ee4defe
     container_name: pi-comet
+    profiles: ["comet", "all"]
     networks:
       - frontend
     expose:
@@ -1189,6 +1205,7 @@ services:
     <<: *service-defaults
     image: lscr.io/linuxserver/prowlarr:2.5.2
     container_name: pi-prowlarr
+    profiles: ["prowlarr", "all"]
     networks:
       - frontend
     dns:
@@ -1231,6 +1248,7 @@ services:
     <<: *service-defaults
     image: mrcas/kapowarr:v1.3.1
     container_name: pi-kapowarr
+    profiles: ["kapowarr", "all"]
     # Same gluetun namespace as qBittorrent (localhost:8080) so torrent path mapping
     # is an identity mapping; GetComics direct downloads also go through the VPN.
     network_mode: "service:gluetun"
@@ -1276,6 +1294,7 @@ services:
     <<: *service-defaults
     image: ghcr.io/flaresolverr/flaresolverr:v3.5.0
     container_name: pi-flaresolverr
+    profiles: ["flaresolverr", "prowlarr", "all"]
     networks:
       - frontend
     dns:
@@ -1300,6 +1319,7 @@ services:
     <<: *service-defaults
     image: lscr.io/linuxserver/kavita:0.9.0
     container_name: pi-kavita
+    profiles: ["kavita", "all"]
     networks:
       - frontend
     extra_hosts:
@@ -1405,6 +1425,7 @@ services:
     <<: *service-defaults
     image: vaultwarden/server:1.37.1
     container_name: pi-vaultwarden
+    profiles: ["vaultwarden", "all"]
     networks:
       - frontend
       - vault
@@ -1599,6 +1620,7 @@ services:
     <<: *service-defaults
     image: ghcr.io/ggml-org/llama.cpp:server-b10481
     container_name: pi-llama-cpp
+    profiles: ["llama-cpp", "all"]
     networks:
       - ai
     expose:
@@ -1669,6 +1691,7 @@ services:
       dockerfile: Dockerfile
     image: pi-piper:local
     container_name: pi-piper
+    profiles: ["piper", "all"]
     networks:
       - ai
     expose:
@@ -1716,6 +1739,7 @@ services:
       dockerfile: Dockerfile
     image: pi-parakeet:local
     container_name: pi-parakeet
+    profiles: ["parakeet", "all"]
     networks:
       - ai
     expose:
@@ -1758,6 +1782,7 @@ services:
       dockerfile: Dockerfile
     image: pi-system-tools:local
     container_name: pi-system-tools
+    profiles: ["system-tools", "all"]
     networks:
       - ai
       # `devices` reads headscale's node API, which only listens on frontend.
@@ -1817,6 +1842,7 @@ services:
     <<: *service-defaults
     image: ghcr.io/open-webui/open-webui:v0.11.0
     container_name: pi-open-webui
+    profiles: ["open-webui", "all"]
     networks:
       - frontend
       - ai
@@ -1869,12 +1895,14 @@ services:
         condition: service_healthy
       llama-cpp:
         condition: service_started
+        required: false
       # service_started, not service_healthy: system-tools is on the relaxed
       # healthcheck (120s interval, no start_interval), so Docker's first probe
       # lands at t=120s and the chat UI would wait for it on every boot - for a
       # tool server that is only ever called mid-conversation.
       system-tools:
         condition: service_started
+        required: false
     healthcheck:
       <<: *healthcheck-relaxed
       test: ["CMD", "curl", "-fsS", "http://localhost:8080"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -326,6 +326,7 @@ services:
     container_name: pi-beszel-agent
     profiles: ["beszel-agent", "all"]
     labels:
+      - "homepage.description=Host metrics collector for Beszel"
       - "pi-pcloud.companion-of=beszel"
     depends_on:
       beszel:
@@ -578,6 +579,7 @@ services:
     container_name: pi-n8n-runners
     profiles: ["n8n-runners", "all"]
     labels:
+      - "homepage.description=Sandboxed task runner for n8n"
       - "pi-pcloud.companion-of=n8n"
     environment:
       - N8N_RUNNERS_TASK_BROKER_URI=http://n8n:5679
@@ -761,6 +763,7 @@ services:
     container_name: pi-immich-machine-learning
     profiles: ["immich-machine-learning", "all"]
     labels:
+      - "homepage.description=Face and object recognition for Immich"
       - "pi-pcloud.companion-of=immich-server"
     image: ghcr.io/immich-app/immich-machine-learning:v3.1.0
     networks:
@@ -1303,6 +1306,7 @@ services:
     container_name: pi-flaresolverr
     profiles: ["flaresolverr", "prowlarr", "all"]
     labels:
+      - "homepage.description=Cloudflare challenge solver for Prowlarr"
       - "pi-pcloud.companion-of=prowlarr"
     networks:
       - frontend

--- a/config/systemd/system/nextcloud-cron.service
+++ b/config/systemd/system/nextcloud-cron.service
@@ -5,4 +5,8 @@ Requires=docker.service
 
 [Service]
 Type=oneshot
+# Skip the run when the nextcloud service is disabled via COMPOSE_PROFILES
+# (exit 1 marks the run "skipped", not failed). No EnvironmentFile= here:
+# run-if-enabled.sh reads COMPOSE_PROFILES from the project .env itself.
+ExecCondition=/bin/sh __PROJECT_PATH__/scripts/run-if-enabled.sh nextcloud
 ExecStart=/usr/bin/docker exec -u www-data pi-nextcloud php -f /var/www/html/cron.php

--- a/config/systemd/system/pi-pcloud.service
+++ b/config/systemd/system/pi-pcloud.service
@@ -8,28 +8,32 @@ Wants=pi-pcloud-authelia-ntfy.service
 [Service]
 Type=oneshot
 WorkingDirectory=__PROJECT_PATH__
+# Back-compat default for installs whose .env predates per-service profiles
+# (no COMPOSE_PROFILES line): enable everything. A COMPOSE_PROFILES line in
+# .env overrides this (EnvironmentFile= wins over Environment=).
+Environment=COMPOSE_PROFILES=all
 EnvironmentFile=__PROJECT_PATH__/.env
 ExecStartPre=-/usr/sbin/ethtool -K eth0 rx-udp-gro-forwarding on rx-gro-list off
 ExecStartPre=/bin/sh __PROJECT_PATH__/scripts/authelia-pre-start.sh
 ExecStartPre=/bin/sh __PROJECT_PATH__/scripts/headscale-pre-start.sh
 ExecStartPre=/bin/sh __PROJECT_PATH__/scripts/backrest-pre-start.sh
 ExecStartPre=/bin/sh __PROJECT_PATH__/scripts/ntfy-pre-start.sh
-ExecStartPre=/bin/sh __PROJECT_PATH__/scripts/qbittorrent-pre-start.sh
-ExecStartPre=/bin/sh __PROJECT_PATH__/scripts/prowlarr-pre-start.sh
-ExecStartPre=/bin/sh __PROJECT_PATH__/scripts/kapowarr-pre-start.sh
-ExecStartPre=/bin/sh __PROJECT_PATH__/scripts/llama-cpp-pre-start.sh
+ExecStartPre=/bin/sh __PROJECT_PATH__/scripts/run-if-enabled.sh qbittorrent /bin/sh __PROJECT_PATH__/scripts/qbittorrent-pre-start.sh
+ExecStartPre=/bin/sh __PROJECT_PATH__/scripts/run-if-enabled.sh prowlarr /bin/sh __PROJECT_PATH__/scripts/prowlarr-pre-start.sh
+ExecStartPre=/bin/sh __PROJECT_PATH__/scripts/run-if-enabled.sh kapowarr /bin/sh __PROJECT_PATH__/scripts/kapowarr-pre-start.sh
+ExecStartPre=/bin/sh __PROJECT_PATH__/scripts/run-if-enabled.sh llama-cpp /bin/sh __PROJECT_PATH__/scripts/llama-cpp-pre-start.sh
 ExecStart=/usr/bin/docker compose up -d
 ExecStartPost=-/bin/sh __PROJECT_PATH__/scripts/headscale-init.sh
-ExecStartPost=-/bin/sh __PROJECT_PATH__/scripts/beszel-agent-bootstrap.sh
-ExecStartPost=-/bin/sh __PROJECT_PATH__/scripts/dockhand-oidc-bootstrap.sh
-ExecStartPost=-/bin/sh __PROJECT_PATH__/scripts/nextcloud-oidc-bootstrap.sh
+ExecStartPost=-/bin/sh __PROJECT_PATH__/scripts/run-if-enabled.sh beszel-agent /bin/sh __PROJECT_PATH__/scripts/beszel-agent-bootstrap.sh
+ExecStartPost=-/bin/sh __PROJECT_PATH__/scripts/run-if-enabled.sh dockhand /bin/sh __PROJECT_PATH__/scripts/dockhand-oidc-bootstrap.sh
+ExecStartPost=-/bin/sh __PROJECT_PATH__/scripts/run-if-enabled.sh nextcloud /bin/sh __PROJECT_PATH__/scripts/nextcloud-oidc-bootstrap.sh
 ExecStartPost=-/bin/sh __PROJECT_PATH__/scripts/pihole-bootstrap.sh
-ExecStartPost=-/bin/sh __PROJECT_PATH__/scripts/qbittorrent-bootstrap.sh
-ExecStartPost=-/bin/sh __PROJECT_PATH__/scripts/prowlarr-bootstrap.sh
-ExecStartPost=-/bin/sh __PROJECT_PATH__/scripts/kapowarr-bootstrap.sh
-ExecStartPost=-/bin/sh __PROJECT_PATH__/scripts/uptime-kuma-bootstrap.sh
-ExecStartPost=-/bin/sh __PROJECT_PATH__/scripts/kavita-oidc-bootstrap.sh
-ExecStartPost=-/bin/sh __PROJECT_PATH__/scripts/open-webui-bootstrap.sh
+ExecStartPost=-/bin/sh __PROJECT_PATH__/scripts/run-if-enabled.sh qbittorrent /bin/sh __PROJECT_PATH__/scripts/qbittorrent-bootstrap.sh
+ExecStartPost=-/bin/sh __PROJECT_PATH__/scripts/run-if-enabled.sh prowlarr /bin/sh __PROJECT_PATH__/scripts/prowlarr-bootstrap.sh
+ExecStartPost=-/bin/sh __PROJECT_PATH__/scripts/run-if-enabled.sh kapowarr /bin/sh __PROJECT_PATH__/scripts/kapowarr-bootstrap.sh
+ExecStartPost=-/bin/sh __PROJECT_PATH__/scripts/run-if-enabled.sh uptime-kuma /bin/sh __PROJECT_PATH__/scripts/uptime-kuma-bootstrap.sh
+ExecStartPost=-/bin/sh __PROJECT_PATH__/scripts/run-if-enabled.sh kavita /bin/sh __PROJECT_PATH__/scripts/kavita-oidc-bootstrap.sh
+ExecStartPost=-/bin/sh __PROJECT_PATH__/scripts/run-if-enabled.sh open-webui /bin/sh __PROJECT_PATH__/scripts/open-webui-bootstrap.sh
 ExecStartPost=-/bin/sh __PROJECT_PATH__/scripts/homepage-widgets-bootstrap.sh
 ExecStop=/usr/bin/docker compose down --remove-orphans
 RemainAfterExit=true

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -15,8 +15,9 @@ Run all commands from the pi-pcloud directory: `/opt/pi-pcloud`
 | `make status` | Show stack status and port bindings |
 | `make logs` | Follow live logs |
 | `make services` | List optional services and whether each is enabled (`COMPOSE_PROFILES`) |
-| `make enable s=<service>` | Enable an optional service: update `COMPOSE_PROFILES` in `.env` and start it |
+| `make enable s=<service>` | Enable an optional service: update `COMPOSE_PROFILES` in `.env`, start it, run its init hooks |
 | `make disable s=<service>` | Disable an optional service: update `COMPOSE_PROFILES` in `.env` and stop it |
+| `make config` | Interactive checklist to choose which optional services run |
 | `make update` | `git pull` + restart |
 | `make doctor` | Report anything outside its threshold: disk, RAM, swap, temperature, load, containers, restarts, backups |
 | `make check-env` | Validate required `.env` variables |
@@ -49,9 +50,9 @@ make restart
 **Toggle optional services** (see [Configuration → Choosing which services run](CONFIGURATION.md#choosing-which-services-run)):
 ```bash
 make services                           # What is enabled right now?
-make enable s=stremio                   # Auto-starts gluetun too
+make config                             # Interactive checklist (whiptail)
+make enable s=stremio                   # Auto-starts gluetun too, runs init hooks
 make disable s=n8n
-make restart                            # Sync the systemd-managed stack
 ```
 
 **View service logs:**

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -14,6 +14,9 @@ Run all commands from the pi-pcloud directory: `/opt/pi-pcloud`
 | `make restart` | Restart all services (after config changes) |
 | `make status` | Show stack status and port bindings |
 | `make logs` | Follow live logs |
+| `make services` | List optional services and whether each is enabled (`COMPOSE_PROFILES`) |
+| `make enable s=<service>` | Enable an optional service: update `COMPOSE_PROFILES` in `.env` and start it |
+| `make disable s=<service>` | Disable an optional service: update `COMPOSE_PROFILES` in `.env` and stop it |
 | `make update` | `git pull` + restart |
 | `make doctor` | Report anything outside its threshold: disk, RAM, swap, temperature, load, containers, restarts, backups |
 | `make check-env` | Validate required `.env` variables |
@@ -41,6 +44,14 @@ make logs
 **After editing `.env`:**
 ```bash
 make restart
+```
+
+**Toggle optional services** (see [Configuration → Choosing which services run](CONFIGURATION.md#choosing-which-services-run)):
+```bash
+make services                           # What is enabled right now?
+make enable s=stremio                   # Auto-starts gluetun too
+make disable s=n8n
+make restart                            # Sync the systemd-managed stack
 ```
 
 **View service logs:**

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -228,7 +228,7 @@ Choose which services run — applying starts and stops containers now
 24/24 enabled · Traefik, Authelia, Pi-hole, Headscale, Postgres … always run
 ── Download ──────────────────────────────────────────────────────────────
  [x] prowlarr                   Indexer manager
- [x]   flaresolverr             runs with prowlarr
+ [x]   flaresolverr             Cloudflare challenge solver for Prowlarr
  [x] qbittorrent                Torrent client (VPN protected)
 ── Video ─────────────────────────────────────────────────────────────────
  [x] stremio                    Streaming server (VPN protected)
@@ -241,7 +241,7 @@ Three things drive that layout, all read out of `compose.yaml` so the picker can
 |-------------------|---------|
 | `homepage.group=` | the section the service is listed under (same label the dashboard uses) |
 | `pi-pcloud.companion-of=` | pointless on its own — drawn indented under that service (`comet` under `stremio`, `immich-machine-learning` under `immich-server`) |
-| `homepage.description=` | the one-line description shown beside the service (a sidecar without one shows what it runs with) |
+| `homepage.description=` | the one-line description shown beside the service; without a `homepage.group` it stays off the dashboard, so a sidecar can be described without being listed there |
 | `profiles:` listing other services | cannot run without this one — `gluetun` for the containers sharing its network namespace |
 
 The last two are deliberately different relations. `qbittorrent` needs `gluetun` but is a service in its own right, so it stays under **Download** rather than being buried under the VPN; `comet` only makes sense with `stremio`, so it sits under it.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -221,7 +221,18 @@ make enable s=stremio    # Add it to COMPOSE_PROFILES and start it (plus depende
 make disable s=stremio   # Remove it from COMPOSE_PROFILES and stop it
 ```
 
-`make config` opens a whiptail checklist of every optional service (checked = currently enabled, including auto-enabled dependencies); on confirm it rewrites `COMPOSE_PROFILES` and starts/stops whatever changed. `enable`/`disable` do the same for a single service, rewriting the `COMPOSE_PROFILES` line in `.env` (materializing the full explicit list first if it was `all` or unset). Enabling also runs the service's init hooks — `scripts/<service>-pre-start.sh` before the start, `scripts/<service>-bootstrap.sh` / `scripts/<service>-oidc-bootstrap.sh` after — the same scripts the systemd unit runs, so no `make restart` is needed: the stack is immediately consistent, and the unit reads the same `.env` at next boot. All three targets are thin wrappers around `scripts/services.sh`.
+`make config` opens a whiptail checklist of every optional service (checked = currently enabled, including auto-enabled dependencies); on confirm it rewrites `COMPOSE_PROFILES` and starts/stops whatever changed. Rows are grouped into sections and coupled services are shown as a tree — an indented service also starts the one above it:
+
+```
+[*] n8n                    Automation
+[*] `- n8n-runners         also starts n8n
+[*] gluetun                Privacy
+[*] |- kapowarr            also starts gluetun
+[*] |- qbittorrent         also starts gluetun
+[*] `- stremio             also starts gluetun
+```
+
+Sections come from the `homepage.group=` labels and the tree from the `profiles:` lists, both read out of `compose.yaml`, so the checklist cannot drift from the stack. Unchecking a service that another checked service auto-activates changes nothing, and says so. `enable`/`disable` do the same for a single service, rewriting the `COMPOSE_PROFILES` line in `.env` (materializing the full explicit list first if it was `all` or unset). Enabling also runs the service's init hooks — `scripts/<service>-pre-start.sh` before the start, `scripts/<service>-bootstrap.sh` / `scripts/<service>-oidc-bootstrap.sh` after — the same scripts the systemd unit runs, so no `make restart` is needed: the stack is immediately consistent, and the unit reads the same `.env` at next boot. All three targets are thin wrappers around `scripts/services.sh`.
 
 ## Custom Configuration
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -182,6 +182,46 @@ These are auto-generated; no manual configuration needed:
 |------|---------|--------------|
 | `config/headplane/headscale_api_key` | Headplane → Headscale admin API access | `scripts/headscale-init.sh` |
 
+## Choosing which services run
+
+Every optional service in `compose.yaml` carries a [Docker Compose profile](https://docs.docker.com/compose/how-tos/profiles/) named after itself (plus a catch-all `all` profile). The `COMPOSE_PROFILES` variable in `.env` selects which ones run:
+
+```env
+# Everything (the default — also the behavior when the line is absent):
+COMPOSE_PROFILES=all
+
+# Or a comma-separated selection:
+COMPOSE_PROFILES=immich-server,nextcloud,stremio,open-webui,llama-cpp
+
+# Explicitly empty = core services only:
+COMPOSE_PROFILES=
+```
+
+An install whose `.env` predates this feature (no `COMPOSE_PROFILES` line) keeps running everything: the systemd unit defaults the variable to `all`. Manual `docker compose` invocations do not get that default, so add `COMPOSE_PROFILES=all` to your `.env` when upgrading.
+
+**Core services always run** (they have no profile): `ddns-updater`, `backrest`, `traefik`, `unbound`, `pihole`, `headscale`, `tailscale`, `ntfy`, `lldap`, `authelia`, `postgres`, `redis`, `homepage`. Pi-hole + Unbound stay core because subdomain DNS resolution (the Pi-hole wildcard record pointing `*.<HOST_NAME>` at the Pi) depends on them, and Headscale + Tailscale stay core because they provide remote access to everything else.
+
+**Optional services** (profile = service name): `beszel`, `beszel-agent`, `uptime-kuma`, `dockhand`, `n8n`, `n8n-runners`, `headplane`, `immich-machine-learning`, `immich-server`, `nextcloud`, `gluetun`, `qbittorrent`, `stremio`, `comet`, `prowlarr`, `kapowarr`, `flaresolverr`, `kavita`, `vaultwarden`, `llama-cpp`, `piper`, `parakeet`, `system-tools`, `open-webui`.
+
+**Some services auto-enable their dependencies** — the dependency carries the dependent's profile too, so enabling one starts both:
+
+| Enabling | Also starts |
+|----------|-------------|
+| `qbittorrent`, `stremio`, or `kapowarr` | `gluetun` (their VPN network namespace) |
+| `n8n-runners` | `n8n` |
+| `beszel-agent` | `beszel` |
+| `prowlarr` | `flaresolverr` |
+
+**Manage the selection with make** (or edit `COMPOSE_PROFILES` by hand and `make restart`):
+
+```bash
+make services            # List each optional service and whether it is enabled
+make enable s=stremio    # Add it to COMPOSE_PROFILES and start it (plus dependencies)
+make disable s=stremio   # Remove it from COMPOSE_PROFILES and stop it
+```
+
+`enable`/`disable` rewrite the `COMPOSE_PROFILES` line in `.env` (materializing the full explicit list first if it was `all` or unset), then start or stop the container. Finish with `make restart` so the systemd-managed stack state matches the new selection.
+
 ## Custom Configuration
 
 ### Overriding Defaults
@@ -197,40 +237,11 @@ To customize, either:
 
 Changes require: `make restart`
 
-### Disabling Containers with `compose.override.yaml`
+### Disabling Containers
 
-Use `compose.override.yaml` to disable optional services without editing `compose.yaml`.
+Optional services are toggled through built-in Compose profiles — see [Choosing which services run](#choosing-which-services-run) and `make enable` / `make disable`. A `compose.override.yaml` is no longer needed for this (and note that `profiles:` lists *merge* across compose files, so an override can only add activation profiles, never remove the built-in ones).
 
-`docker compose` automatically loads:
-- `compose.yaml`
-- `compose.override.yaml` (if present)
-
-To disable a service by default, assign it to a profile that you do not enable (for example `disabled`):
-
-```yaml
-services:
-  n8n:
-    profiles:
-      - disabled
-
-  n8n-runners:
-    profiles:
-      - disabled
-
-  open-webui:
-    profiles:
-      - disabled
-```
-
-With this override in place:
-- `make start` / `make restart` keeps those services stopped
-- The rest of the stack starts normally
-
-To re-enable one temporarily, start it with its profile explicitly enabled.
-
-To make it permanent again, remove the `profiles` block for that service from `compose.override.yaml` and restart the stack.
-
-Verify what is running with `make status` (or `docker compose ps`).
+Verify what is running with `make services` and `make status` (or `docker compose ps`).
 
 ### Adding New Services
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -221,19 +221,29 @@ make enable s=stremio    # Add it to COMPOSE_PROFILES and start it (plus depende
 make disable s=stremio   # Remove it from COMPOSE_PROFILES and stop it
 ```
 
-`make config` opens a terminal picker listing every optional service (ticked = currently enabled, including auto-enabled dependencies); on confirm it rewrites `COMPOSE_PROFILES` and starts/stops whatever changed. Services are grouped into sections, and one that only runs with another is indented under it:
+`make config` opens a terminal picker listing every optional service (ticked = currently enabled, including auto-enabled dependencies); on confirm it rewrites `COMPOSE_PROFILES` and starts/stops whatever changed. Services are listed under the section they belong to, and one that is pointless on its own is indented under the service it belongs to:
 
 ```
-── Privacy ──────────────────────────
- [x] gluetun
- [x]   kapowarr
- [x]   qbittorrent
- [x]   stremio
+── Download ─────────────────────────
+ [x] prowlarr
+ [x]   flaresolverr
+ [x] qbittorrent
+── Video ────────────────────────────
+ [x] stremio
+ [x]   comet
 ```
 
-Sections come from the `homepage.group=` labels and the nesting from the `profiles:` lists, both read out of `compose.yaml`, so the list cannot drift from the stack.
+Three things drive that layout, all read out of `compose.yaml` so the picker cannot drift from the stack:
 
-Linked services move together as you toggle, in both directions: unticking `gluetun` unticks the services that run inside its network namespace, and ticking one of them ticks `gluetun` back (its profile is what starts it, so it would come up regardless).
+| In `compose.yaml` | Meaning |
+|-------------------|---------|
+| `homepage.group=` | the section the service is listed under (same label the dashboard uses) |
+| `pi-pcloud.companion-of=` | pointless on its own — drawn indented under that service (`comet` under `stremio`, `immich-machine-learning` under `immich-server`) |
+| `profiles:` listing other services | cannot run without this one — `gluetun` for the containers sharing its network namespace |
+
+The last two are deliberately different relations. `qbittorrent` needs `gluetun` but is a service in its own right, so it stays under **Download** rather than being buried under the VPN; `comet` only makes sense with `stremio`, so it sits under it.
+
+Toggling propagates along both relations, transitively, so the screen always shows a set the stack can actually run: unticking `gluetun` unticks `qbittorrent`, `kapowarr`, `stremio` and — through `stremio` — `comet`; ticking `comet` ticks `stremio` and `gluetun` back. The footer names whatever moved.
 
 The picker is `scripts/services-picker.py` — Python's standard-library `curses`, so nothing to install on Raspberry Pi OS, and it only chooses: reading `compose.yaml`, writing `.env` and running the hooks all stay in `scripts/services.sh`. On a host without `python3`, use `make enable` / `make disable`, which need no TUI at all. `enable`/`disable` do the same for a single service, rewriting the `COMPOSE_PROFILES` line in `.env` (materializing the full explicit list first if it was `all` or unset). Enabling also runs the service's init hooks — `scripts/<service>-pre-start.sh` before the start, `scripts/<service>-bootstrap.sh` / `scripts/<service>-oidc-bootstrap.sh` after — the same scripts the systemd unit runs, so no `make restart` is needed: the stack is immediately consistent, and the unit reads the same `.env` at next boot. All three targets are thin wrappers around `scripts/services.sh`.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -224,13 +224,15 @@ make disable s=stremio   # Remove it from COMPOSE_PROFILES and stop it
 `make config` opens a terminal picker listing every optional service (ticked = currently enabled, including auto-enabled dependencies); on confirm it rewrites `COMPOSE_PROFILES` and starts/stops whatever changed. Services are listed under the section they belong to, and one that is pointless on its own is indented under the service it belongs to:
 
 ```
-── Download ─────────────────────────
- [x] prowlarr
- [x]   flaresolverr
- [x] qbittorrent
-── Video ────────────────────────────
- [x] stremio
- [x]   comet
+Choose which services run — applying starts and stops containers now
+24/24 enabled · Traefik, Authelia, Pi-hole, Headscale, Postgres … always run
+── Download ──────────────────────────────────────────────────────────────
+ [x] prowlarr                   Indexer manager
+ [x]   flaresolverr             runs with prowlarr
+ [x] qbittorrent                Torrent client (VPN protected)
+── Video ─────────────────────────────────────────────────────────────────
+ [x] stremio                    Streaming server (VPN protected)
+ [x]   comet                    Stremio debrid addon
 ```
 
 Three things drive that layout, all read out of `compose.yaml` so the picker cannot drift from the stack:
@@ -239,6 +241,7 @@ Three things drive that layout, all read out of `compose.yaml` so the picker can
 |-------------------|---------|
 | `homepage.group=` | the section the service is listed under (same label the dashboard uses) |
 | `pi-pcloud.companion-of=` | pointless on its own — drawn indented under that service (`comet` under `stremio`, `immich-machine-learning` under `immich-server`) |
+| `homepage.description=` | the one-line description shown beside the service (a sidecar without one shows what it runs with) |
 | `profiles:` listing other services | cannot run without this one — `gluetun` for the containers sharing its network namespace |
 
 The last two are deliberately different relations. `qbittorrent` needs `gluetun` but is a service in its own right, so it stays under **Download** rather than being buried under the VPN; `comet` only makes sense with `stremio`, so it sits under it.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -221,20 +221,21 @@ make enable s=stremio    # Add it to COMPOSE_PROFILES and start it (plus depende
 make disable s=stremio   # Remove it from COMPOSE_PROFILES and stop it
 ```
 
-`make config` opens a whiptail checklist of every optional service (checked = currently enabled, including auto-enabled dependencies); on confirm it rewrites `COMPOSE_PROFILES` and starts/stops whatever changed. Rows are grouped into sections, and a service that only runs with another is indented under it:
+`make config` opens a terminal picker listing every optional service (ticked = currently enabled, including auto-enabled dependencies); on confirm it rewrites `COMPOSE_PROFILES` and starts/stops whatever changed. Services are grouped into sections, and one that only runs with another is indented under it:
 
 ```
-[*] n8n                    Automation
-[*]   - n8n-runners
-[*] gluetun                Privacy
-[*]   - kapowarr
-[*]   - qbittorrent
-[*]   - stremio
+── Privacy ──────────────────────────
+ [x] gluetun
+ [x]   kapowarr
+ [x]   qbittorrent
+ [x]   stremio
 ```
 
-Sections come from the `homepage.group=` labels and the nesting from the `profiles:` lists, both read out of `compose.yaml`, so the checklist cannot drift from the stack.
+Sections come from the `homepage.group=` labels and the nesting from the `profiles:` lists, both read out of `compose.yaml`, so the list cannot drift from the stack.
 
-Linked services move together in both directions: unticking `gluetun` unticks the services that run inside its network namespace, and ticking one of them ticks `gluetun` back (its profile is what starts it, so it would come up regardless). whiptail cannot toggle a row from a callback, so the adjusted selection is shown again — with a note naming what moved and why — for you to confirm or keep editing. `enable`/`disable` do the same for a single service, rewriting the `COMPOSE_PROFILES` line in `.env` (materializing the full explicit list first if it was `all` or unset). Enabling also runs the service's init hooks — `scripts/<service>-pre-start.sh` before the start, `scripts/<service>-bootstrap.sh` / `scripts/<service>-oidc-bootstrap.sh` after — the same scripts the systemd unit runs, so no `make restart` is needed: the stack is immediately consistent, and the unit reads the same `.env` at next boot. All three targets are thin wrappers around `scripts/services.sh`.
+Linked services move together as you toggle, in both directions: unticking `gluetun` unticks the services that run inside its network namespace, and ticking one of them ticks `gluetun` back (its profile is what starts it, so it would come up regardless).
+
+The picker is `scripts/services-picker.py` — Python's standard-library `curses`, so nothing to install on Raspberry Pi OS, and it only chooses: reading `compose.yaml`, writing `.env` and running the hooks all stay in `scripts/services.sh`. On a host without `python3`, use `make enable` / `make disable`, which need no TUI at all. `enable`/`disable` do the same for a single service, rewriting the `COMPOSE_PROFILES` line in `.env` (materializing the full explicit list first if it was `all` or unset). Enabling also runs the service's init hooks — `scripts/<service>-pre-start.sh` before the start, `scripts/<service>-bootstrap.sh` / `scripts/<service>-oidc-bootstrap.sh` after — the same scripts the systemd unit runs, so no `make restart` is needed: the stack is immediately consistent, and the unit reads the same `.env` at next boot. All three targets are thin wrappers around `scripts/services.sh`.
 
 ## Custom Configuration
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -221,18 +221,20 @@ make enable s=stremio    # Add it to COMPOSE_PROFILES and start it (plus depende
 make disable s=stremio   # Remove it from COMPOSE_PROFILES and stop it
 ```
 
-`make config` opens a whiptail checklist of every optional service (checked = currently enabled, including auto-enabled dependencies); on confirm it rewrites `COMPOSE_PROFILES` and starts/stops whatever changed. Rows are grouped into sections, and a service that pulls in another is indented under it:
+`make config` opens a whiptail checklist of every optional service (checked = currently enabled, including auto-enabled dependencies); on confirm it rewrites `COMPOSE_PROFILES` and starts/stops whatever changed. Rows are grouped into sections, and a service that only runs with another is indented under it:
 
 ```
 [*] n8n                    Automation
-[*] |- n8n-runners
+[*]   - n8n-runners
 [*] gluetun                Privacy
-[*] |- kapowarr
-[*] |- qbittorrent
-[*] |- stremio
+[*]   - kapowarr
+[*]   - qbittorrent
+[*]   - stremio
 ```
 
-Sections come from the `homepage.group=` labels and the tree from the `profiles:` lists, both read out of `compose.yaml`, so the checklist cannot drift from the stack. Ticking an indented service enables the one it hangs off — leaving that box unticked only means it was not asked for explicitly, so `make config` adds it back and says which service needed it. `enable`/`disable` do the same for a single service, rewriting the `COMPOSE_PROFILES` line in `.env` (materializing the full explicit list first if it was `all` or unset). Enabling also runs the service's init hooks — `scripts/<service>-pre-start.sh` before the start, `scripts/<service>-bootstrap.sh` / `scripts/<service>-oidc-bootstrap.sh` after — the same scripts the systemd unit runs, so no `make restart` is needed: the stack is immediately consistent, and the unit reads the same `.env` at next boot. All three targets are thin wrappers around `scripts/services.sh`.
+Sections come from the `homepage.group=` labels and the nesting from the `profiles:` lists, both read out of `compose.yaml`, so the checklist cannot drift from the stack.
+
+Linked services move together in both directions: unticking `gluetun` unticks the services that run inside its network namespace, and ticking one of them ticks `gluetun` back (its profile is what starts it, so it would come up regardless). whiptail cannot toggle a row from a callback, so the adjusted selection is shown again — with a note naming what moved and why — for you to confirm or keep editing. `enable`/`disable` do the same for a single service, rewriting the `COMPOSE_PROFILES` line in `.env` (materializing the full explicit list first if it was `all` or unset). Enabling also runs the service's init hooks — `scripts/<service>-pre-start.sh` before the start, `scripts/<service>-bootstrap.sh` / `scripts/<service>-oidc-bootstrap.sh` after — the same scripts the systemd unit runs, so no `make restart` is needed: the stack is immediately consistent, and the unit reads the same `.env` at next boot. All three targets are thin wrappers around `scripts/services.sh`.
 
 ## Custom Configuration
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -221,18 +221,18 @@ make enable s=stremio    # Add it to COMPOSE_PROFILES and start it (plus depende
 make disable s=stremio   # Remove it from COMPOSE_PROFILES and stop it
 ```
 
-`make config` opens a whiptail checklist of every optional service (checked = currently enabled, including auto-enabled dependencies); on confirm it rewrites `COMPOSE_PROFILES` and starts/stops whatever changed. Rows are grouped into sections and coupled services are shown as a tree — an indented service also starts the one above it:
+`make config` opens a whiptail checklist of every optional service (checked = currently enabled, including auto-enabled dependencies); on confirm it rewrites `COMPOSE_PROFILES` and starts/stops whatever changed. Rows are grouped into sections, and a service that pulls in another is indented under it:
 
 ```
 [*] n8n                    Automation
-[*] `- n8n-runners         also starts n8n
+[*] |- n8n-runners
 [*] gluetun                Privacy
-[*] |- kapowarr            also starts gluetun
-[*] |- qbittorrent         also starts gluetun
-[*] `- stremio             also starts gluetun
+[*] |- kapowarr
+[*] |- qbittorrent
+[*] |- stremio
 ```
 
-Sections come from the `homepage.group=` labels and the tree from the `profiles:` lists, both read out of `compose.yaml`, so the checklist cannot drift from the stack. Unchecking a service that another checked service auto-activates changes nothing, and says so. `enable`/`disable` do the same for a single service, rewriting the `COMPOSE_PROFILES` line in `.env` (materializing the full explicit list first if it was `all` or unset). Enabling also runs the service's init hooks — `scripts/<service>-pre-start.sh` before the start, `scripts/<service>-bootstrap.sh` / `scripts/<service>-oidc-bootstrap.sh` after — the same scripts the systemd unit runs, so no `make restart` is needed: the stack is immediately consistent, and the unit reads the same `.env` at next boot. All three targets are thin wrappers around `scripts/services.sh`.
+Sections come from the `homepage.group=` labels and the tree from the `profiles:` lists, both read out of `compose.yaml`, so the checklist cannot drift from the stack. Ticking an indented service enables the one it hangs off — leaving that box unticked only means it was not asked for explicitly, so `make config` adds it back and says which service needed it. `enable`/`disable` do the same for a single service, rewriting the `COMPOSE_PROFILES` line in `.env` (materializing the full explicit list first if it was `all` or unset). Enabling also runs the service's init hooks — `scripts/<service>-pre-start.sh` before the start, `scripts/<service>-bootstrap.sh` / `scripts/<service>-oidc-bootstrap.sh` after — the same scripts the systemd unit runs, so no `make restart` is needed: the stack is immediately consistent, and the unit reads the same `.env` at next boot. All three targets are thin wrappers around `scripts/services.sh`.
 
 ## Custom Configuration
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -215,12 +215,13 @@ An install whose `.env` predates this feature (no `COMPOSE_PROFILES` line) keeps
 **Manage the selection with make** (or edit `COMPOSE_PROFILES` by hand and `make restart`):
 
 ```bash
+make config              # Interactive checklist — the comfortable path
 make services            # List each optional service and whether it is enabled
 make enable s=stremio    # Add it to COMPOSE_PROFILES and start it (plus dependencies)
 make disable s=stremio   # Remove it from COMPOSE_PROFILES and stop it
 ```
 
-`enable`/`disable` rewrite the `COMPOSE_PROFILES` line in `.env` (materializing the full explicit list first if it was `all` or unset), then start or stop the container. Finish with `make restart` so the systemd-managed stack state matches the new selection.
+`make config` opens a whiptail checklist of every optional service (checked = currently enabled, including auto-enabled dependencies); on confirm it rewrites `COMPOSE_PROFILES` and starts/stops whatever changed. `enable`/`disable` do the same for a single service, rewriting the `COMPOSE_PROFILES` line in `.env` (materializing the full explicit list first if it was `all` or unset). Enabling also runs the service's init hooks — `scripts/<service>-pre-start.sh` before the start, `scripts/<service>-bootstrap.sh` / `scripts/<service>-oidc-bootstrap.sh` after — the same scripts the systemd unit runs, so no `make restart` is needed: the stack is immediately consistent, and the unit reads the same `.env` at next boot. All three targets are thin wrappers around `scripts/services.sh`.
 
 ## Custom Configuration
 

--- a/scripts/run-if-enabled.sh
+++ b/scripts/run-if-enabled.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+# Gate per-service pre-start/bootstrap work on COMPOSE_PROFILES.
+#
+# Usage:
+#   run-if-enabled.sh <service> <command> [args...]
+#       Exec <command> if <service> is enabled; otherwise print a short
+#       skip notice and exit 0 (so blocking ExecStartPre lines pass).
+#   run-if-enabled.sh <service>
+#       Test mode: exit 0 if enabled, 1 if disabled. Meant for systemd
+#       ExecCondition, where a 1..254 exit skips the unit without failing it.
+#
+# A service is enabled when the comma-separated COMPOSE_PROFILES list contains
+# "all" or the exact service name (no substring matching; spaces around
+# entries are tolerated). A defined-but-empty value disables every optional
+# service, matching what docker compose does with it (core-only). Only when
+# COMPOSE_PROFILES is defined nowhere (an install predating per-service
+# profiles) is everything treated as enabled.
+#
+# When COMPOSE_PROFILES is not set in the environment (a unit without
+# EnvironmentFile=, e.g. nextcloud-cron.service), it is read from the .env
+# file in this script's parent directory instead.
+#
+# Deliberately self-contained: does NOT source lib.sh, so it stays usable
+# from minimal contexts (some repo scripts are mounted into containers).
+
+set -eu
+
+if [ "$#" -lt 1 ]; then
+    echo "Usage: $(basename "$0") <service> [command ...]" >&2
+    exit 2
+fi
+
+service="$1"
+shift
+
+profiles="${COMPOSE_PROFILES-}"
+defined="${COMPOSE_PROFILES+x}"
+
+# Fallback: COMPOSE_PROFILES not exported at all -> read the project .env.
+if [ -z "$defined" ]; then
+    env_file="$(cd "$(dirname "$0")/.." && pwd)/.env"
+    if [ -f "$env_file" ] && grep -q '^COMPOSE_PROFILES=' "$env_file"; then
+        defined=x
+        profiles="$(grep '^COMPOSE_PROFILES=' "$env_file" | tail -n1 | cut -d'=' -f2- | tr -d '\r')"
+        # Strip optional surrounding quotes.
+        case "$profiles" in
+            \"*\") profiles="${profiles#\"}"; profiles="${profiles%\"}" ;;
+            \'*\') profiles="${profiles#\'}"; profiles="${profiles%\'}" ;;
+        esac
+    fi
+fi
+
+# service_enabled <profiles> <service>: 0 if enabled, 1 if disabled.
+# Empty list -> disabled: that is what docker compose runs (core-only).
+service_enabled() {
+    _profiles="$1"
+    _service="$2"
+
+    set -f
+    IFS=', '
+    # shellcheck disable=SC2086 # intentional split on commas (and spaces)
+    set -- $_profiles
+    unset IFS
+    set +f
+
+    for _entry in "$@"; do
+        if [ "$_entry" = "all" ] || [ "$_entry" = "$_service" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# COMPOSE_PROFILES defined nowhere -> legacy install, everything enabled.
+if [ -z "$defined" ] || service_enabled "$profiles" "$service"; then
+    [ "$#" -gt 0 ] || exit 0
+    exec "$@"
+fi
+
+# Disabled.
+[ "$#" -gt 0 ] || exit 1
+echo "run-if-enabled: $service disabled (COMPOSE_PROFILES=$profiles), skipping: $*"
+exit 0

--- a/scripts/run-if-enabled.sh
+++ b/scripts/run-if-enabled.sh
@@ -77,7 +77,6 @@ if [ -z "$defined" ] || service_enabled "$profiles" "$service"; then
     exec "$@"
 fi
 
-# Disabled.
 [ "$#" -gt 0 ] || exit 1
 echo "run-if-enabled: $service disabled (COMPOSE_PROFILES=$profiles), skipping: $*"
 exit 0

--- a/scripts/services-picker.py
+++ b/scripts/services-picker.py
@@ -3,7 +3,8 @@
 
 Usage: services-picker.py <rows-file> <out-file>
 
-The rows file holds one service per line, "service:section:companion-of:needs:state",
+The rows file holds one service per line, as
+"service:section:companion-of:needs:state:description",
 as produced by scripts/services.sh (which owns everything else: reading
 compose.yaml, writing .env, running the per-service hooks). This script only
 lets the user choose, then writes the services that stay ticked to the out
@@ -23,7 +24,9 @@ transitively, so the screen always shows a set the stack can actually run.
 import curses
 import sys
 
-HELP = "space toggle  a all  n none  enter apply  q cancel"
+HELP = "space toggle · a all · n none · enter apply · q cancel"
+# Title, count and the blank line the sections start after.
+HEADER = 2
 
 
 def read_rows(path):
@@ -34,10 +37,10 @@ def read_rows(path):
             line = line.rstrip("\n")
             if not line:
                 continue
-            fields = line.split(":", 4)
-            if len(fields) != 5:
+            fields = line.split(":", 5)
+            if len(fields) != 6:
                 sys.exit(f"services-picker: malformed row {line!r}")
-            service, section, parent, needs, state = fields
+            service, section, parent, needs, state, description = fields
             rows.append({
                 "service": service,
                 "section": section,
@@ -45,6 +48,7 @@ def read_rows(path):
                 # Everything this service cannot run without, companion included.
                 "needs": [n for n in ([parent] if parent else []) + needs.split() if n],
                 "on": state == "on",
+                "description": description,
             })
     return rows
 
@@ -106,26 +110,38 @@ def set_all(rows, on):
         row["on"] = on
 
 
-def draw(win, rows, lines, cursor, offset, message):
+def name_column(rows):
+    """Width of the service column, so the descriptions line up."""
+    return max(len(("  " if row["parent"] else "") + row["service"]) for row in rows)
+
+
+def draw(win, rows, lines, cursor, offset, message, column):
     win.erase()
     height, width = win.getmaxyx()
-    body = max(height - 3, 1)
-    win.addnstr(0, 0, "Optional services — core infrastructure always runs",
+    body = max(height - HEADER - 1, 1)
+    enabled = sum(1 for row in rows if row["on"])
+    # Two lines that fit 80 columns: what this screen does, then what it will
+    # not touch — the services that are missing from the list on purpose.
+    win.addnstr(0, 0, "Choose which services run — applying starts and stops containers now",
                 width - 1, curses.A_BOLD)
+    win.addnstr(1, 0, f"{enabled}/{len(rows)} enabled · Traefik, Authelia, Pi-hole, "
+                      f"Headscale, Postgres … always run", width - 1, curses.A_DIM)
+    # Descriptions only earn their place once the names fit comfortably.
+    room = width - (5 + column + 2)
     for screen_row, line_index in enumerate(range(offset, min(offset + body, len(lines)))):
         kind, payload = lines[line_index]
-        y = screen_row + 1
+        y = screen_row + HEADER
         if kind == "head":
             win.addnstr(y, 0, f"── {payload} ".ljust(width - 1, "─"), width - 1, curses.A_DIM)
             continue
         row = rows[payload]
-        indent = "  " if row["parent"] else ""
-        text = f" [{'x' if row['on'] else ' '}] {indent}{row['service']}"
+        name = ("  " if row["parent"] else "") + row["service"]
+        text = f" [{'x' if row['on'] else ' '}] {name}"
+        if row["description"] and room >= 16:
+            text = f"{text.ljust(5 + column + 2)}{row['description']}"
         attr = curses.A_REVERSE if line_index == cursor else curses.A_NORMAL
         win.addnstr(y, 0, text.ljust(width - 1), width - 1, attr)
-    selected = sum(1 for row in rows if row["on"])
-    footer = message or f"{selected}/{len(rows)} selected   {HELP}"
-    win.addnstr(height - 1, 0, footer[:width - 1], width - 1, curses.A_DIM)
+    win.addnstr(height - 1, 0, (message or HELP)[:width - 1], width - 1, curses.A_DIM)
     win.refresh()
 
 
@@ -153,12 +169,13 @@ def run(screen, rows):
         return False
     offset = 0
     message = ""
+    column = name_column(rows)
     while True:
-        height = max(screen.getmaxyx()[0] - 3, 1)
+        height = max(screen.getmaxyx()[0] - HEADER - 1, 1)
         offset = min(offset, cursor)
         if cursor >= offset + height:
             offset = cursor - height + 1
-        draw(screen, rows, lines, cursor, offset, message)
+        draw(screen, rows, lines, cursor, offset, message, column)
         key = screen.getch()
         if key in (ord("q"), 27):
             return False

--- a/scripts/services-picker.py
+++ b/scripts/services-picker.py
@@ -3,21 +3,21 @@
 
 Usage: services-picker.py <rows-file> <out-file>
 
-The rows file holds one service per line, "service:section:parent:state",
+The rows file holds one service per line, "service:section:companion-of:needs:state",
 as produced by scripts/services.sh (which owns everything else: reading
 compose.yaml, writing .env, running the per-service hooks). This script only
-lets the user choose, then writes the selected service names to the out file,
-one per line. Exit status is 0 on confirm, 1 on cancel.
+lets the user choose, then writes the services that stay ticked to the out
+file, one per line. Exit status is 0 on confirm, 1 on cancel.
 
 Files rather than stdio: curses owns the terminal, so a captured stdout would
 either swallow the UI or the result.
 
-Linked services move together as the boxes are toggled: a service that only
-runs with another (qbittorrent inside gluetun's network namespace, n8n-runners
-behind n8n) is indented under it, unticking the one it hangs off unticks it
-too, and ticking it back ticks that one. Compose behaves the same way -- the
-child's own profile activates the parent -- so the screen matches what the
-stack will do.
+Two relations reach us, and they are deliberately different. `companion-of` is
+"pointless on its own" -- comet only makes sense with stremio, n8n-runners with
+n8n -- and is drawn as an indented row. `needs` is "cannot run without", which
+crosses sections: qbittorrent is a download service listed under Download, but
+it runs inside gluetun's network namespace. Toggling propagates along both,
+transitively, so the screen always shows a set the stack can actually run.
 """
 
 import curses
@@ -27,88 +27,105 @@ HELP = "space toggle  a all  n none  enter apply  q cancel"
 
 
 def read_rows(path):
-    """[(service, section, parent, on)] in display order."""
+    """Rows in display order, as dicts."""
     rows = []
     with open(path) as handle:
         for line in handle:
             line = line.rstrip("\n")
             if not line:
                 continue
-            fields = line.split(":", 3)
-            if len(fields) != 4:
+            fields = line.split(":", 4)
+            if len(fields) != 5:
                 sys.exit(f"services-picker: malformed row {line!r}")
-            service, section, parent, state = fields
-            rows.append((service, section, parent, state == "on"))
+            service, section, parent, needs, state = fields
+            rows.append({
+                "service": service,
+                "section": section,
+                "parent": parent,
+                # Everything this service cannot run without, companion included.
+                "needs": [n for n in ([parent] if parent else []) + needs.split() if n],
+                "on": state == "on",
+            })
     return rows
 
 
 def build_lines(rows):
-    """Display lines: ("head", section) or ("svc", index), section headers included."""
+    """Display lines: ("head", section) or ("svc", row index)."""
     lines = []
     section = None
-    for index, (_service, svc_section, parent, _on) in enumerate(rows):
-        if not parent and svc_section != section:
-            section = svc_section
+    for index, row in enumerate(rows):
+        if row["section"] and row["section"] != section:
+            section = row["section"]
             lines.append(("head", section))
         lines.append(("svc", index))
     return lines
 
 
-def children_of(rows, service):
-    return [i for i, row in enumerate(rows) if row[2] == service]
-
-
-def parent_index(rows, index):
-    parent = rows[index][2]
-    if not parent:
-        return None
-    for i, row in enumerate(rows):
-        if row[0] == parent:
-            return i
+def index_of(rows, service):
+    for index, row in enumerate(rows):
+        if row["service"] == service:
+            return index
     return None
 
 
 def toggle(rows, index):
-    """Flip one box, then carry the services linked to it along."""
-    on = not rows[index][3]
-    rows[index] = rows[index][:3] + (on,)
-    if on:
-        # It cannot run alone: the one it hangs off comes with it.
-        parent = parent_index(rows, index)
-        if parent is not None and not rows[parent][3]:
-            rows[parent] = rows[parent][:3] + (True,)
-    else:
-        # Nothing that only runs with it can stay.
-        for child in children_of(rows, rows[index][0]):
-            if rows[child][3]:
-                rows[child] = rows[child][:3] + (False,)
+    """Flip one box and carry along whatever cannot run without it.
+
+    Ticking pulls in everything the service needs; unticking drops everything
+    that needs it. Both walk the graph, so comet pulls in stremio and gluetun,
+    and dropping gluetun drops stremio and comet with it.
+    """
+    on = not rows[index]["on"]
+    rows[index]["on"] = on
+    moved = []
+    pending = [index]
+    while pending:
+        current = pending.pop()
+        if on:
+            for service in rows[current]["needs"]:
+                target = index_of(rows, service)
+                if target is not None and not rows[target]["on"]:
+                    rows[target]["on"] = True
+                    moved.append(service)
+                    pending.append(target)
+        else:
+            dropped = rows[current]["service"]
+            for target, row in enumerate(rows):
+                if row["on"] and dropped in row["needs"]:
+                    row["on"] = False
+                    moved.append(row["service"])
+                    pending.append(target)
+    if not moved:
+        return ""
+    verb = "also ticked" if on else "also unticked"
+    return f"{verb}: {' '.join(sorted(set(moved)))}"
 
 
 def set_all(rows, on):
-    for i, row in enumerate(rows):
-        rows[i] = row[:3] + (on,)
+    for row in rows:
+        row["on"] = on
 
 
-def draw(win, rows, lines, cursor, offset):
+def draw(win, rows, lines, cursor, offset, message):
     win.erase()
     height, width = win.getmaxyx()
     body = max(height - 3, 1)
-    win.addnstr(0, 0, "Optional services — core infrastructure always runs", width - 1,
-                curses.A_BOLD)
+    win.addnstr(0, 0, "Optional services — core infrastructure always runs",
+                width - 1, curses.A_BOLD)
     for screen_row, line_index in enumerate(range(offset, min(offset + body, len(lines)))):
         kind, payload = lines[line_index]
         y = screen_row + 1
         if kind == "head":
             win.addnstr(y, 0, f"── {payload} ".ljust(width - 1, "─"), width - 1, curses.A_DIM)
             continue
-        service, _section, parent, on = rows[payload]
-        indent = "  " if parent else ""
-        text = f" [{'x' if on else ' '}] {indent}{service}"
+        row = rows[payload]
+        indent = "  " if row["parent"] else ""
+        text = f" [{'x' if row['on'] else ' '}] {indent}{row['service']}"
         attr = curses.A_REVERSE if line_index == cursor else curses.A_NORMAL
         win.addnstr(y, 0, text.ljust(width - 1), width - 1, attr)
-    selected = sum(1 for row in rows if row[3])
-    win.addnstr(height - 1, 0, f"{selected}/{len(rows)} selected   {HELP}"[:width - 1],
-                width - 1, curses.A_DIM)
+    selected = sum(1 for row in rows if row["on"])
+    footer = message or f"{selected}/{len(rows)} selected   {HELP}"
+    win.addnstr(height - 1, 0, footer[:width - 1], width - 1, curses.A_DIM)
     win.refresh()
 
 
@@ -135,17 +152,19 @@ def run(screen, rows):
     if cursor is None:
         return False
     offset = 0
+    message = ""
     while True:
         height = max(screen.getmaxyx()[0] - 3, 1)
         offset = min(offset, cursor)
         if cursor >= offset + height:
             offset = cursor - height + 1
-        draw(screen, rows, lines, cursor, offset)
+        draw(screen, rows, lines, cursor, offset, message)
         key = screen.getch()
         if key in (ord("q"), 27):
             return False
         if key in (curses.KEY_ENTER, 10, 13):
             return True
+        message = ""
         if key in (curses.KEY_DOWN, ord("j")):
             cursor = move(lines, cursor, cursor + 1, 1)
         elif key in (curses.KEY_UP, ord("k")):
@@ -155,7 +174,7 @@ def run(screen, rows):
         elif key == curses.KEY_PPAGE:
             cursor = move(lines, cursor, max(cursor - height, 0), 1)
         elif key == ord(" "):
-            toggle(rows, lines[cursor][1])
+            message = toggle(rows, lines[cursor][1])
         elif key == ord("a"):
             set_all(rows, True)
         elif key == ord("n"):
@@ -166,7 +185,7 @@ def run(screen, rows):
 
 def main():
     if len(sys.argv) != 3:
-        print(__doc__.strip().splitlines()[2], file=sys.stderr)
+        print("usage: services-picker.py <rows-file> <out-file>", file=sys.stderr)
         return 2
     rows = read_rows(sys.argv[1])
     if not rows:
@@ -175,9 +194,9 @@ def main():
     if not curses.wrapper(run, rows):
         return 1
     with open(sys.argv[2], "w") as handle:
-        for service, _section, _parent, on in rows:
-            if on:
-                handle.write(service + "\n")
+        for row in rows:
+            if row["on"]:
+                handle.write(row["service"] + "\n")
     return 0
 
 

--- a/scripts/services-picker.py
+++ b/scripts/services-picker.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Interactive picker for the optional services of the stack.
+
+Usage: services-picker.py <rows-file> <out-file>
+
+The rows file holds one service per line, "service:section:parent:state",
+as produced by scripts/services.sh (which owns everything else: reading
+compose.yaml, writing .env, running the per-service hooks). This script only
+lets the user choose, then writes the selected service names to the out file,
+one per line. Exit status is 0 on confirm, 1 on cancel.
+
+Files rather than stdio: curses owns the terminal, so a captured stdout would
+either swallow the UI or the result.
+
+Linked services move together as the boxes are toggled: a service that only
+runs with another (qbittorrent inside gluetun's network namespace, n8n-runners
+behind n8n) is indented under it, unticking the one it hangs off unticks it
+too, and ticking it back ticks that one. Compose behaves the same way -- the
+child's own profile activates the parent -- so the screen matches what the
+stack will do.
+"""
+
+import curses
+import sys
+
+HELP = "space toggle  a all  n none  enter apply  q cancel"
+
+
+def read_rows(path):
+    """[(service, section, parent, on)] in display order."""
+    rows = []
+    with open(path) as handle:
+        for line in handle:
+            line = line.rstrip("\n")
+            if not line:
+                continue
+            fields = line.split(":", 3)
+            if len(fields) != 4:
+                sys.exit(f"services-picker: malformed row {line!r}")
+            service, section, parent, state = fields
+            rows.append((service, section, parent, state == "on"))
+    return rows
+
+
+def build_lines(rows):
+    """Display lines: ("head", section) or ("svc", index), section headers included."""
+    lines = []
+    section = None
+    for index, (_service, svc_section, parent, _on) in enumerate(rows):
+        if not parent and svc_section != section:
+            section = svc_section
+            lines.append(("head", section))
+        lines.append(("svc", index))
+    return lines
+
+
+def children_of(rows, service):
+    return [i for i, row in enumerate(rows) if row[2] == service]
+
+
+def parent_index(rows, index):
+    parent = rows[index][2]
+    if not parent:
+        return None
+    for i, row in enumerate(rows):
+        if row[0] == parent:
+            return i
+    return None
+
+
+def toggle(rows, index):
+    """Flip one box, then carry the services linked to it along."""
+    on = not rows[index][3]
+    rows[index] = rows[index][:3] + (on,)
+    if on:
+        # It cannot run alone: the one it hangs off comes with it.
+        parent = parent_index(rows, index)
+        if parent is not None and not rows[parent][3]:
+            rows[parent] = rows[parent][:3] + (True,)
+    else:
+        # Nothing that only runs with it can stay.
+        for child in children_of(rows, rows[index][0]):
+            if rows[child][3]:
+                rows[child] = rows[child][:3] + (False,)
+
+
+def set_all(rows, on):
+    for i, row in enumerate(rows):
+        rows[i] = row[:3] + (on,)
+
+
+def draw(win, rows, lines, cursor, offset):
+    win.erase()
+    height, width = win.getmaxyx()
+    body = max(height - 3, 1)
+    win.addnstr(0, 0, "Optional services — core infrastructure always runs", width - 1,
+                curses.A_BOLD)
+    for screen_row, line_index in enumerate(range(offset, min(offset + body, len(lines)))):
+        kind, payload = lines[line_index]
+        y = screen_row + 1
+        if kind == "head":
+            win.addnstr(y, 0, f"── {payload} ".ljust(width - 1, "─"), width - 1, curses.A_DIM)
+            continue
+        service, _section, parent, on = rows[payload]
+        indent = "  " if parent else ""
+        text = f" [{'x' if on else ' '}] {indent}{service}"
+        attr = curses.A_REVERSE if line_index == cursor else curses.A_NORMAL
+        win.addnstr(y, 0, text.ljust(width - 1), width - 1, attr)
+    selected = sum(1 for row in rows if row[3])
+    win.addnstr(height - 1, 0, f"{selected}/{len(rows)} selected   {HELP}"[:width - 1],
+                width - 1, curses.A_DIM)
+    win.refresh()
+
+
+def first_service_line(lines, start, step):
+    """Nearest line at or after start (walking by step) that is a service."""
+    index = start
+    while 0 <= index < len(lines):
+        if lines[index][0] == "svc":
+            return index
+        index += step
+    return None
+
+
+def move(lines, cursor, start, step):
+    """Cursor after a move, staying on a service line and inside the list."""
+    target = first_service_line(lines, start, step)
+    return cursor if target is None else target
+
+
+def run(screen, rows):
+    curses.curs_set(0)
+    lines = build_lines(rows)
+    cursor = first_service_line(lines, 0, 1)
+    if cursor is None:
+        return False
+    offset = 0
+    while True:
+        height = max(screen.getmaxyx()[0] - 3, 1)
+        offset = min(offset, cursor)
+        if cursor >= offset + height:
+            offset = cursor - height + 1
+        draw(screen, rows, lines, cursor, offset)
+        key = screen.getch()
+        if key in (ord("q"), 27):
+            return False
+        if key in (curses.KEY_ENTER, 10, 13):
+            return True
+        if key in (curses.KEY_DOWN, ord("j")):
+            cursor = move(lines, cursor, cursor + 1, 1)
+        elif key in (curses.KEY_UP, ord("k")):
+            cursor = move(lines, cursor, cursor - 1, -1)
+        elif key == curses.KEY_NPAGE:
+            cursor = move(lines, cursor, min(cursor + height, len(lines) - 1), -1)
+        elif key == curses.KEY_PPAGE:
+            cursor = move(lines, cursor, max(cursor - height, 0), 1)
+        elif key == ord(" "):
+            toggle(rows, lines[cursor][1])
+        elif key == ord("a"):
+            set_all(rows, True)
+        elif key == ord("n"):
+            set_all(rows, False)
+        elif key == curses.KEY_RESIZE:
+            offset = 0
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(__doc__.strip().splitlines()[2], file=sys.stderr)
+        return 2
+    rows = read_rows(sys.argv[1])
+    if not rows:
+        print("services-picker: no services to choose from", file=sys.stderr)
+        return 2
+    if not curses.wrapper(run, rows):
+        return 1
+    with open(sys.argv[2], "w") as handle:
+        for service, _section, _parent, on in rows:
+            if on:
+                handle.write(service + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/services.sh
+++ b/scripts/services.sh
@@ -30,7 +30,7 @@
 # which .env compose happens to read.
 #
 # Host-only: this script is never mounted into containers, so sourcing
-# lib.sh is fine here (see docs/../scripts/lib.sh sharing constraints).
+# lib.sh is fine here (scripts that backrest mounts must not source it).
 
 set -eu
 
@@ -265,7 +265,6 @@ cmd_config() {
         return 0
     fi
 
-    # Compute the new COMPOSE_PROFILES value from the selection.
     selection="$(printf '%s\n' "$selection" | grep -v '^$' || true)"
     new_profiles="$(printf '%s\n' "$selection" | grep -v '^$' | paste -sd, - || true)"
     if [ "$(printf '%s\n' "$selection" | sort)" = "$known" ]; then

--- a/scripts/services.sh
+++ b/scripts/services.sh
@@ -78,16 +78,30 @@ write_profiles() {
     else
         printf 'COMPOSE_PROFILES=%s\n' "$1" >> "$ENV_FILE"
     fi
-    echo "✏️  COMPOSE_PROFILES=$1"
+    echo "✏️  Updated COMPOSE_PROFILES in $(basename "$ENV_FILE")"
 }
 
-# Mutating docker compose command (stop/rm). Dry mode prints instead.
+# Mutating docker compose command. Dry mode prints instead.
 run_compose() {
     if is_dry_run; then
         echo "DRY-RUN: docker compose $*"
     else
         compose "$@"
     fi
+}
+
+# Same, with the output held back and replayed only if the command fails:
+# `stop` and `rm` each draw a progress block and `rm` announces every container
+# it is about to remove, which repeats what we just printed ourselves.
+run_compose_quiet() {
+    if is_dry_run; then
+        echo "DRY-RUN: docker compose $*"
+        return 0
+    fi
+    _out="$(compose "$@" 2>&1)" || {
+        printf '%s\n' "$_out" >&2
+        return 1
+    }
 }
 
 # `docker compose up` with the selection passed explicitly, so the started
@@ -308,8 +322,8 @@ cmd_disable() {
         echo "⚠️  $svc is still auto-enabled by another enabled service's profile — it will come back on the next stack restart"
     fi
     echo "🛑 Stopping and removing $svc..."
-    run_compose stop "$svc"
-    run_compose rm -f "$svc"
+    run_compose_quiet stop "$svc"
+    run_compose_quiet rm -f "$svc"
     echo "✅ $svc disabled"
 }
 
@@ -391,27 +405,32 @@ EOF
         return 0
     fi
 
-    for svc in $newly_on; do
-        run_hook "$svc-pre-start.sh"
-    done
+    # Only the services that were just enabled are started, so disabling
+    # something does not redraw the whole stack (and does not rebuild images
+    # to reach a state it is already in).
+    if [ -n "$newly_on" ]; then
+        for svc in $newly_on; do
+            run_hook "$svc-pre-start.sh"
+        done
+        echo "🚀 Starting$newly_on..."
+        # shellcheck disable=SC2086 # service names, split on purpose
+        run_compose_up_with "$new_profiles" up -d $newly_on
+    fi
 
-    echo "🚀 Applying selection (docker compose up -d)..."
-    run_compose_up_with "$new_profiles" up -d
-
-    for svc in $newly_off; do
-        echo "🛑 Stopping and removing $svc..."
-        run_compose stop "$svc"
-        run_compose rm -f "$svc"
-    done
+    if [ -n "$newly_off" ]; then
+        echo "🛑 Stopping and removing$newly_off..."
+        # shellcheck disable=SC2086 # service names, split on purpose
+        run_compose_quiet stop $newly_off
+        # shellcheck disable=SC2086 # service names, split on purpose
+        run_compose_quiet rm -f $newly_off
+    fi
 
     for svc in $newly_on; do
         run_hook "$svc-bootstrap.sh"
         run_hook "$svc-oidc-bootstrap.sh"
     done
 
-    echo "✅ Applied. COMPOSE_PROFILES=${new_profiles:-<empty: core only>}"
-    [ -z "$newly_on" ] || echo "   enabled:$newly_on"
-    [ -z "$newly_off" ] || echo "   disabled:$newly_off"
+    echo "✅ Applied${newly_on:+ · enabled:$newly_on}${newly_off:+ · disabled:$newly_off}"
 }
 
 # --- Main ---

--- a/scripts/services.sh
+++ b/scripts/services.sh
@@ -134,12 +134,15 @@ validate_service() {
 
 # --- Checklist layout ---
 
-# One row per optional service, as "<service>:<section>:<companion-of>:<needs>",
+# One row per optional service, as
+# "<service>:<section>:<companion-of>:<needs>:<description>" (description last,
+# so a colon inside it survives),
 # ordered by section. Three things come out of compose.yaml, so the picker can
 # never drift from the stack:
 #   homepage.group=            the section the service is listed under
 #   pi-pcloud.companion-of=    the service it is pointless without, which is
 #                              what the picker draws it indented beneath
+#   homepage.description=      the one-line description shown beside it
 #   profiles:                  a service listing others in its own profile list
 #                              is a dependency they cannot run without (gluetun
 #                              for the containers sharing its network
@@ -173,6 +176,13 @@ config_rows() {
             sub(/"[ \t]*$/, "", group)
             next
         }
+        /homepage\.description=/ {
+            desc = $0
+            sub(/.*homepage\.description=/, "", desc)
+            sub(/"[ \t]*$/, "", desc)
+            gsub(/\|/, "/", desc)
+            next
+        }
         /pi-pcloud\.companion-of=/ {
             companion = $0
             sub(/.*pi-pcloud\.companion-of=/, "", companion)
@@ -199,7 +209,10 @@ config_rows() {
                 root = comp[i] != "" ? comp[i] : name[i]
                 child = comp[i] != "" ? 1 : 0
                 sub(/^ /, "", needs[name[i]])
-                printf "%s|%s|%d|%s|%s|%s\n", section[name[i]], root, child, name[i], comp[i], needs[name[i]]
+                # A sidecar carries no dashboard description of its own; saying
+                # what it runs with beats an empty column.
+                text = info[i] != "" ? info[i] : (comp[i] != "" ? "runs with " comp[i] : "")
+                printf "%s|%s|%d|%s|%s|%s|%s\n", section[name[i]], root, child, name[i], comp[i], needs[name[i]], text
             }
         }
         function collect() {
@@ -208,17 +221,18 @@ config_rows() {
                 name[n] = svc
                 grp[n] = group
                 comp[n] = companion
+                info[n] = desc
                 p = profiles
                 sub(/^[^[]*\[/, "", p)
                 sub(/\].*$/, "", p)
                 gsub(/["\t ]/, "", p)
                 prof[n] = p
             }
-            svc = ""; profiles = ""; group = ""; companion = ""
+            svc = ""; profiles = ""; group = ""; companion = ""; desc = ""
         }
     ' "$PROJECT_DIR/compose.yaml" \
         | sort -t'|' -k1,1 -k2,2 -k3,3n -k4,4 \
-        | awk -F'|' '{ printf "%s:%s:%s:%s\n", $4, ($3 == 0 ? $1 : ""), $5, $6 }'
+        | awk -F'|' '{ printf "%s:%s:%s:%s:%s\n", $4, ($3 == 0 ? $1 : ""), $5, $6, $7 }'
 }
 
 # --- Subcommands ---
@@ -320,18 +334,19 @@ cmd_config() {
     known="$(known_profiles)"
     old_enabled="$(services_for_profiles "$old_profiles")"
 
-    # The picker only chooses: it reads "service:section:parent:needs:state" and
+    # The picker only chooses: it reads
+    # "service:section:parent:needs:state:description" rows and
     # writes back the services that stay ticked. Files, not a pipe, because it
     # takes over the terminal (see scripts/services-picker.py).
     rows_file="$(mktemp)"
     picked_file="$(mktemp)"
-    while IFS=: read -r svc section parent needs; do
+    while IFS=: read -r svc section parent needs desc; do
         [ -n "$svc" ] || continue
         in_lines "$known" "$svc" || continue
         if in_lines "$old_enabled" "$svc"; then
-            printf '%s:%s:%s:%s:on\n' "$svc" "$section" "$parent" "$needs" >>"$rows_file"
+            printf '%s:%s:%s:%s:on:%s\n' "$svc" "$section" "$parent" "$needs" "$desc" >>"$rows_file"
         else
-            printf '%s:%s:%s:%s:off\n' "$svc" "$section" "$parent" "$needs" >>"$rows_file"
+            printf '%s:%s:%s:%s:off:%s\n' "$svc" "$section" "$parent" "$needs" "$desc" >>"$rows_file"
         fi
     done <<EOF
 $(config_rows)

--- a/scripts/services.sh
+++ b/scripts/services.sh
@@ -132,6 +132,98 @@ validate_service() {
     fi
 }
 
+# --- Checklist layout ---
+
+# One display row per optional service, as "<tag>\t<description>", ordered by
+# section with each coupled pair rendered as a tree. Everything is derived from
+# compose.yaml, so the checklist cannot drift from the stack: a service's
+# `profiles:` list names the dependents that auto-activate it (gluetun carries
+# its netns tenants, n8n carries n8n-runners), which is what makes a pair a
+# tree, and its `homepage.group=` label gives the section. A label-less service
+# borrows its first child's section (flaresolverr sits with prowlarr), else the
+# section of the service it shares a name prefix with (immich-machine-learning
+# sits with immich-server), else "Other". Sorting goes through sort(1) because
+# mawk has no asort. The tree glyphs stay ASCII: whiptail pads the tag column
+# by byte length, so a multi-byte glyph would shift the description column of
+# every child row out of line.
+config_rows() {
+    awk '
+        /^services:[ \t]*$/ { in_services = 1; next }
+        /^[A-Za-z0-9_-]+:/ {
+            if (in_services) collect()
+            in_services = 0
+            next
+        }
+        !in_services { next }
+        /^  [A-Za-z0-9_-]+:[ \t]*$/ {
+            collect()
+            svc = $0
+            gsub(/[ :]/, "", svc)
+            next
+        }
+        /^[ \t]+profiles:/ { profiles = $0; next }
+        /homepage\.group=/ {
+            group = $0
+            sub(/.*homepage\.group=/, "", group)
+            sub(/"[ \t]*$/, "", group)
+            next
+        }
+        END {
+            collect()
+            for (i = 1; i <= n; i++) {
+                cnt = split(prof[i], part, ",")
+                for (j = 1; j <= cnt; j++)
+                    if (part[j] != "" && part[j] != "all" && part[j] != name[i])
+                        parent[part[j]] = name[i]
+            }
+            for (i = 1; i <= n; i++) {
+                if (name[i] in parent) continue
+                g = grp[i]
+                for (k = 1; k <= n && g == ""; k++)
+                    if ((name[k] in parent) && parent[name[k]] == name[i] && grp[k] != "")
+                        g = grp[k]
+                if (g == "") {
+                    pre = name[i]
+                    sub(/-.*$/, "", pre)
+                    for (k = 1; k <= n && g == ""; k++)
+                        if (k != i && grp[k] != "" && index(name[k], pre "-") == 1)
+                            g = grp[k]
+                }
+                if (g == "") g = "Other"
+                section[name[i]] = g
+            }
+            for (i = 1; i <= n; i++)
+                if (name[i] in parent)
+                    printf "%s|%s|1|%s|%s\n", section[parent[name[i]]], parent[name[i]], name[i], parent[name[i]]
+                else
+                    printf "%s|%s|0|%s|\n", section[name[i]], name[i], name[i]
+        }
+        function collect() {
+            if (svc != "" && profiles != "") {
+                n++
+                name[n] = svc
+                grp[n] = group
+                p = profiles
+                sub(/^[^[]*\[/, "", p)
+                sub(/\].*$/, "", p)
+                gsub(/["\t ]/, "", p)
+                prof[n] = p
+            }
+            svc = ""; profiles = ""; group = ""
+        }
+    ' "$PROJECT_DIR/compose.yaml" \
+        | sort -t'|' -k1,1 -k2,2 -k3,3n -k4,4 \
+        | awk -F'|' '
+            { sec[NR] = $1; root[NR] = $2; child[NR] = $3; svc[NR] = $4; par[NR] = $5; n = NR }
+            END {
+                for (i = 1; i <= n; i++) {
+                    if (child[i] == 0) { printf "%s\t%s\n", svc[i], sec[i]; continue }
+                    last = !(i < n && child[i + 1] == 1 && root[i + 1] == root[i])
+                    printf "%s %s\talso starts %s\n", (last ? "`-" : "|-"), svc[i], par[i]
+                }
+            }'
+}
+
 # --- Subcommands ---
 
 cmd_list() {
@@ -234,18 +326,26 @@ cmd_config() {
     known="$(known_profiles)"
     old_enabled="$(services_for_profiles "$old_profiles")"
 
-    # Build the checklist rows: <tag> <status> <on|off>. Checked = currently
-    # enabled (same computation as list, so auto-enabled deps show checked).
+    # Checked = currently enabled (same computation as list, so auto-enabled
+    # dependencies show checked). The tag carries the tree glyphs, so the
+    # service name is its last whitespace-separated word. Fed by a here-doc,
+    # not a pipe, so `set --` lands in this shell.
     count=0
     set --
-    for svc in $known; do
+    tab="$(printf '\t')"
+    while IFS="$tab" read -r tag desc; do
+        [ -n "$tag" ] || continue
+        svc="${tag##* }"
+        in_lines "$known" "$svc" || continue
         if in_lines "$old_enabled" "$svc"; then
-            set -- "$@" "$svc" "enabled" on
+            set -- "$@" "$tag" "$desc" on
         else
-            set -- "$@" "$svc" "disabled" off
+            set -- "$@" "$tag" "$desc" off
         fi
         count=$((count + 1))
-    done
+    done <<EOF
+$(config_rows)
+EOF
     if [ "$count" -eq 0 ]; then
         echo "❌ No optional services declared in compose.yaml" >&2
         exit 1
@@ -259,13 +359,14 @@ cmd_config() {
     # stderr; the fd swap captures them. A non-zero exit means Cancel/Esc.
     if ! selection="$("$dialog_tool" --title "pi-pcloud optional services" \
             --separate-output \
-            --checklist "Choose which optional services run (space toggles, enter applies):" \
-            "$height" 64 "$list_height" "$@" 3>&1 1>&2 2>&3)"; then
+            --checklist "Choose which optional services run (space toggles, enter applies). An indented service also starts the one above it:" \
+            "$height" 72 "$list_height" "$@" 3>&1 1>&2 2>&3)"; then
         echo "Cancelled — no changes."
         return 0
     fi
 
-    selection="$(printf '%s\n' "$selection" | grep -v '^$' || true)"
+    # Back from display tags to service names (drop the tree glyphs).
+    selection="$(printf '%s\n' "$selection" | sed 's/^.* //' | grep -v '^$' || true)"
     new_profiles="$(printf '%s\n' "$selection" | grep -v '^$' | paste -sd, - || true)"
     if [ "$(printf '%s\n' "$selection" | sort)" = "$known" ]; then
         new_profiles=all

--- a/scripts/services.sh
+++ b/scripts/services.sh
@@ -281,6 +281,11 @@ cmd_config() {
     for svc in $known; do
         if in_lines "$new_enabled" "$svc"; then
             in_lines "$old_enabled" "$svc" || newly_on="$newly_on $svc"
+            # Unchecked but still enabled: a checked service activates its
+            # profile too, so the box cannot be cleared on its own. Said here
+            # because the row comes back checked on the next run.
+            in_lines "$selection" "$svc" \
+                || echo "⚠️  $svc stays enabled: another selected service auto-activates it"
         else
             if in_lines "$old_enabled" "$svc"; then newly_off="$newly_off $svc"; fi
         fi

--- a/scripts/services.sh
+++ b/scripts/services.sh
@@ -13,7 +13,7 @@
 #   list               List optional services and whether each is enabled
 #   enable <service>   Add to COMPOSE_PROFILES, start it, run its init hooks
 #   disable <service>  Remove from COMPOSE_PROFILES, stop and remove it
-#   config             Interactive whiptail/dialog checklist of all services
+#   config             Interactive picker (scripts/services-picker.py)
 #
 # enable (and config, for newly-enabled services) runs the same per-service
 # hooks the systemd unit runs around `docker compose up`:
@@ -134,9 +134,9 @@ validate_service() {
 
 # --- Checklist layout ---
 
-# One display row per optional service, as "<tag>:<section>:<parent>",
-# ordered by section, with a service that pulls in another indented under it:
-# an "  - " tag hangs off the row above and <parent> names it. Everything is derived from
+# One row per optional service, as "<service>:<section>:<parent>", ordered by
+# section; <parent> is set when the service only runs with another one, which
+# is what the picker renders as an indented child. Everything is derived from
 # compose.yaml, so the checklist cannot drift from the stack: a service's
 # `profiles:` list names the dependents that auto-activate it (gluetun carries
 # its netns tenants, n8n carries n8n-runners), which is what makes a pair a
@@ -144,11 +144,9 @@ validate_service() {
 # borrows its first child's section (flaresolverr sits with prowlarr), else the
 # section of the service it shares a name prefix with (immich-machine-learning
 # sits with immich-server), else "Other". Sorting goes through sort(1) because
-# mawk has no asort. The indent marker stays ASCII: whiptail pads the tag
-# column by byte length, so a multi-byte glyph would shift the second column of
-# every child row out of line. Fields are colon-separated, not tab-separated: `read`
-# folds runs of IFS whitespace, which would swallow the empty field a row
-# always has (a section has no parent and a child shows no section).
+# mawk has no asort. Fields are colon-separated, not tab-separated: `read` folds
+# runs of IFS whitespace, which would swallow the empty field every row carries
+# (a section has no parent, a child has no section).
 config_rows() {
     awk '
         /^services:[ \t]*$/ { in_services = 1; next }
@@ -225,46 +223,8 @@ config_rows() {
                         gsub(/:/, " ", section)
                         printf "%s:%s:\n", svc[i], section
                     } else
-                        printf "  - %s::%s\n", svc[i], par[i]
+                        printf "%s::%s\n", svc[i], par[i]
             }'
-}
-
-# Linked services move together, in both directions: unticking a parent takes
-# the services hanging off it with it, and ticking one of those ticks the
-# parent back (compose starts it anyway, through the child's own profile).
-# Rule 1 keys off what changed against the state that was on screen, so the
-# two rules cannot fight over a box the user did not touch.
-close_selection() {
-    _sel="$1"
-    _shown="$2"
-    _edges="$3"
-    while IFS=' ' read -r _child _parent; do
-        [ -n "$_parent" ] || continue
-        in_lines "$_shown" "$_parent" || continue
-        in_lines "$_sel" "$_parent" && continue
-        _sel="$(printf '%s\n' "$_sel" | grep -vx "$_child" || true)"
-    done <<EOF
-$_edges
-EOF
-    while IFS=' ' read -r _child _parent; do
-        [ -n "$_parent" ] || continue
-        in_lines "$_sel" "$_child" || continue
-        in_lines "$_sel" "$_parent" && continue
-        _sel="$_sel
-$_parent"
-    done <<EOF
-$_edges
-EOF
-    printf '%s\n' "$_sel" | grep -v '^$' | sort -u || true
-}
-
-# missing_from <list-a> <list-b>: entries of a absent from b, space-joined.
-missing_from() {
-    _out=""
-    for _item in $1; do
-        in_lines "$2" "$_item" || _out="$_out $_item"
-    done
-    printf '%s' "${_out# }"
 }
 
 # --- Subcommands ---
@@ -352,12 +312,9 @@ cmd_config() {
         echo "   or use 'make enable s=<service>' / 'make disable s=<service>' instead." >&2
         exit 1
     fi
-    if command -v whiptail >/dev/null 2>&1; then
-        dialog_tool=whiptail
-    elif command -v dialog >/dev/null 2>&1; then
-        dialog_tool=dialog
-    else
-        echo "❌ 'config' needs whiptail or dialog installed (sudo apt install whiptail)." >&2
+    if ! command -v python3 >/dev/null 2>&1; then
+        echo "❌ 'config' needs python3 (shipped with Raspberry Pi OS). Without it," >&2
+        echo "   use 'make enable s=<service>' / 'make disable s=<service>'." >&2
         exit 1
     fi
 
@@ -369,80 +326,38 @@ cmd_config() {
     known="$(known_profiles)"
     old_enabled="$(services_for_profiles "$old_profiles")"
 
-    # The rows never change, only their tick state, so read them once. The tag
-    # carries the indent marker, so the service name is its last
-    # whitespace-separated word. Fed by a here-doc, not a pipe, so the
-    # assignments land in this shell.
-    rows=""
-    edges=""
-    count=0
-    while IFS=: read -r tag desc parent; do
-        [ -n "$tag" ] || continue
-        svc="${tag##* }"
+    # The picker only chooses: it reads "service:section:parent:state" rows and
+    # writes back the services that stay ticked. Files, not a pipe, because it
+    # takes over the terminal (see scripts/services-picker.py).
+    rows_file="$(mktemp)"
+    picked_file="$(mktemp)"
+    while IFS=: read -r svc section parent; do
+        [ -n "$svc" ] || continue
         in_lines "$known" "$svc" || continue
-        rows="$rows$tag:$desc
-"
-        [ -z "$parent" ] || edges="$edges$svc $parent
-"
-        count=$((count + 1))
+        if in_lines "$old_enabled" "$svc"; then
+            printf '%s:%s:%s:on\n' "$svc" "$section" "$parent" >>"$rows_file"
+        else
+            printf '%s:%s:%s:off\n' "$svc" "$section" "$parent" >>"$rows_file"
+        fi
     done <<EOF
 $(config_rows)
 EOF
-    if [ "$count" -eq 0 ]; then
+    if [ ! -s "$rows_file" ]; then
+        rm -f "$rows_file" "$picked_file"
         echo "❌ No optional services declared in compose.yaml" >&2
         exit 1
     fi
 
-    list_height=$count
-    [ "$list_height" -le 14 ] || list_height=14
-    height=$((list_height + 8))
+    if python3 "$PROJECT_DIR/scripts/services-picker.py" "$rows_file" "$picked_file"; then
+        selection="$(sort -u "$picked_file")"
+    else
+        rm -f "$rows_file" "$picked_file"
+        echo "Cancelled — no changes."
+        return 0
+    fi
+    rm -f "$rows_file" "$picked_file"
 
-    # Shown ticked, then re-shown whenever the linked services move a box the
-    # user did not touch: whiptail has no way to toggle a row from a callback,
-    # so the adjusted state comes back on screen to be confirmed or edited.
-    shown="$(printf '%s\n' "$old_enabled" | grep -v '^$' | sort -u || true)"
-    note=""
-    while :; do
-        set --
-        while IFS=: read -r tag desc; do
-            [ -n "$tag" ] || continue
-            svc="${tag##* }"
-            if in_lines "$shown" "$svc"; then
-                set -- "$@" "$tag" "$desc" on
-            else
-                set -- "$@" "$tag" "$desc" off
-            fi
-        done <<EOF
-$rows
-EOF
-        # whiptail/dialog draw the UI on the terminal and print the chosen tags
-        # on stderr; the fd swap captures them. Non-zero means Cancel/Esc.
-        if ! selection="$("$dialog_tool" --title "pi-pcloud optional services" \
-                --separate-output \
-                --checklist "${note}Choose which optional services run (space toggles, enter applies). An indented service runs with the one above it, and the two are ticked and unticked together:" \
-                "$height" 72 "$list_height" "$@" 3>&1 1>&2 2>&3)"; then
-            echo "Cancelled — no changes."
-            return 0
-        fi
-
-        # Back from display tags to service names (drop the indent marker).
-        selection="$(printf '%s\n' "$selection" | sed 's/^.* //' | grep -v '^$' | sort -u || true)"
-        closed="$(close_selection "$selection" "$shown" "$edges")"
-        [ "$closed" != "$selection" ] || break
-
-        added="$(missing_from "$closed" "$selection")"
-        removed="$(missing_from "$selection" "$closed")"
-        note=""
-        [ -z "$added" ] || note="${note}Also ticked (needed by a ticked service): $added
-"
-        [ -z "$removed" ] || note="${note}Also unticked (they only run with the service you unticked): $removed
-"
-        note="$note
-"
-        shown="$closed"
-    done
-    selection="$closed"
-    new_profiles="$(printf '%s\n' "$selection" | paste -sd, - || true)"
+    new_profiles="$(printf '%s\n' "$selection" | grep -v '^$' | paste -sd, - || true)"
     if [ "$(printf '%s\n' "$selection" | sort)" = "$known" ]; then
         new_profiles=all
     fi

--- a/scripts/services.sh
+++ b/scripts/services.sh
@@ -134,19 +134,23 @@ validate_service() {
 
 # --- Checklist layout ---
 
-# One row per optional service, as "<service>:<section>:<parent>", ordered by
-# section; <parent> is set when the service only runs with another one, which
-# is what the picker renders as an indented child. Everything is derived from
-# compose.yaml, so the checklist cannot drift from the stack: a service's
-# `profiles:` list names the dependents that auto-activate it (gluetun carries
-# its netns tenants, n8n carries n8n-runners), which is what makes a pair a
-# tree, and its `homepage.group=` label gives the section. A label-less service
-# borrows its first child's section (flaresolverr sits with prowlarr), else the
-# section of the service it shares a name prefix with (immich-machine-learning
-# sits with immich-server), else "Other". Sorting goes through sort(1) because
-# mawk has no asort. Fields are colon-separated, not tab-separated: `read` folds
-# runs of IFS whitespace, which would swallow the empty field every row carries
-# (a section has no parent, a child has no section).
+# One row per optional service, as "<service>:<section>:<companion-of>:<needs>",
+# ordered by section. Three things come out of compose.yaml, so the picker can
+# never drift from the stack:
+#   homepage.group=            the section the service is listed under
+#   pi-pcloud.companion-of=    the service it is pointless without, which is
+#                              what the picker draws it indented beneath
+#   profiles:                  a service listing others in its own profile list
+#                              is a dependency they cannot run without (gluetun
+#                              for the containers sharing its network
+#                              namespace), reported as <needs>
+# The last two are different relations on purpose: qbittorrent needs gluetun but
+# is a service in its own right, listed under Download, while comet only makes
+# sense under stremio. Both propagate when a box is toggled; only companion-of
+# nests. A service with no section label borrows its companion's, else "Other".
+# Sorting goes through sort(1) because mawk has no asort. Fields are
+# colon-separated, not tab-separated: `read` folds runs of IFS whitespace, which
+# would swallow the empty fields a row carries.
 config_rows() {
     awk '
         /^services:[ \t]*$/ { in_services = 1; next }
@@ -169,62 +173,52 @@ config_rows() {
             sub(/"[ \t]*$/, "", group)
             next
         }
+        /pi-pcloud\.companion-of=/ {
+            companion = $0
+            sub(/.*pi-pcloud\.companion-of=/, "", companion)
+            sub(/"[ \t]*$/, "", companion)
+            next
+        }
         END {
             collect()
             for (i = 1; i <= n; i++) {
                 cnt = split(prof[i], part, ",")
                 for (j = 1; j <= cnt; j++)
                     if (part[j] != "" && part[j] != "all" && part[j] != name[i])
-                        parent[part[j]] = name[i]
+                        needs[part[j]] = needs[part[j]] " " name[i]
             }
             for (i = 1; i <= n; i++) {
-                if (name[i] in parent) continue
                 g = grp[i]
-                for (k = 1; k <= n && g == ""; k++)
-                    if ((name[k] in parent) && parent[name[k]] == name[i] && grp[k] != "")
-                        g = grp[k]
-                if (g == "") {
-                    pre = name[i]
-                    sub(/-.*$/, "", pre)
-                    for (k = 1; k <= n && g == ""; k++)
-                        if (k != i && grp[k] != "" && index(name[k], pre "-") == 1)
-                            g = grp[k]
-                }
+                if (g == "" && comp[i] != "")
+                    for (k = 1; k <= n; k++)
+                        if (name[k] == comp[i] && grp[k] != "") g = grp[k]
                 if (g == "") g = "Other"
                 section[name[i]] = g
             }
-            for (i = 1; i <= n; i++)
-                if (name[i] in parent)
-                    printf "%s|%s|1|%s|%s\n", section[parent[name[i]]], parent[name[i]], name[i], parent[name[i]]
-                else
-                    printf "%s|%s|0|%s|\n", section[name[i]], name[i], name[i]
+            for (i = 1; i <= n; i++) {
+                root = comp[i] != "" ? comp[i] : name[i]
+                child = comp[i] != "" ? 1 : 0
+                sub(/^ /, "", needs[name[i]])
+                printf "%s|%s|%d|%s|%s|%s\n", section[name[i]], root, child, name[i], comp[i], needs[name[i]]
+            }
         }
         function collect() {
             if (svc != "" && profiles != "") {
                 n++
                 name[n] = svc
                 grp[n] = group
+                comp[n] = companion
                 p = profiles
                 sub(/^[^[]*\[/, "", p)
                 sub(/\].*$/, "", p)
                 gsub(/["\t ]/, "", p)
                 prof[n] = p
             }
-            svc = ""; profiles = ""; group = ""
+            svc = ""; profiles = ""; group = ""; companion = ""
         }
     ' "$PROJECT_DIR/compose.yaml" \
         | sort -t'|' -k1,1 -k2,2 -k3,3n -k4,4 \
-        | awk -F'|' '
-            { sec[NR] = $1; root[NR] = $2; child[NR] = $3; svc[NR] = $4; par[NR] = $5; n = NR }
-            END {
-                for (i = 1; i <= n; i++)
-                    if (child[i] == 0) {
-                        section = sec[i]
-                        gsub(/:/, " ", section)
-                        printf "%s:%s:\n", svc[i], section
-                    } else
-                        printf "%s::%s\n", svc[i], par[i]
-            }'
+        | awk -F'|' '{ printf "%s:%s:%s:%s\n", $4, ($3 == 0 ? $1 : ""), $5, $6 }'
 }
 
 # --- Subcommands ---
@@ -326,18 +320,18 @@ cmd_config() {
     known="$(known_profiles)"
     old_enabled="$(services_for_profiles "$old_profiles")"
 
-    # The picker only chooses: it reads "service:section:parent:state" rows and
+    # The picker only chooses: it reads "service:section:parent:needs:state" and
     # writes back the services that stay ticked. Files, not a pipe, because it
     # takes over the terminal (see scripts/services-picker.py).
     rows_file="$(mktemp)"
     picked_file="$(mktemp)"
-    while IFS=: read -r svc section parent; do
+    while IFS=: read -r svc section parent needs; do
         [ -n "$svc" ] || continue
         in_lines "$known" "$svc" || continue
         if in_lines "$old_enabled" "$svc"; then
-            printf '%s:%s:%s:on\n' "$svc" "$section" "$parent" >>"$rows_file"
+            printf '%s:%s:%s:%s:on\n' "$svc" "$section" "$parent" "$needs" >>"$rows_file"
         else
-            printf '%s:%s:%s:off\n' "$svc" "$section" "$parent" >>"$rows_file"
+            printf '%s:%s:%s:%s:off\n' "$svc" "$section" "$parent" "$needs" >>"$rows_file"
         fi
     done <<EOF
 $(config_rows)

--- a/scripts/services.sh
+++ b/scripts/services.sh
@@ -134,8 +134,11 @@ validate_service() {
 
 # --- Checklist layout ---
 
-# One display row per optional service, as "<tag>\t<description>", ordered by
-# section with each coupled pair rendered as a tree. Everything is derived from
+# One display row per optional service, as "<tag>:<section>:<parent>",
+# ordered by section with each coupled pair rendered as a tree: a "|- " tag is
+# a service that pulls in the one it hangs off, and <parent> names it. Every
+# child gets the same glyph - the classic last-child variant would only claim
+# that nothing follows, which the section layout already shows. Everything is derived from
 # compose.yaml, so the checklist cannot drift from the stack: a service's
 # `profiles:` list names the dependents that auto-activate it (gluetun carries
 # its netns tenants, n8n carries n8n-runners), which is what makes a pair a
@@ -143,9 +146,11 @@ validate_service() {
 # borrows its first child's section (flaresolverr sits with prowlarr), else the
 # section of the service it shares a name prefix with (immich-machine-learning
 # sits with immich-server), else "Other". Sorting goes through sort(1) because
-# mawk has no asort. The tree glyphs stay ASCII: whiptail pads the tag column
-# by byte length, so a multi-byte glyph would shift the description column of
-# every child row out of line.
+# mawk has no asort. The glyph stays ASCII: whiptail pads the tag column by
+# byte length, so a multi-byte glyph would shift the second column of every
+# child row out of line. Fields are colon-separated, not tab-separated: `read`
+# folds runs of IFS whitespace, which would swallow the empty field a row
+# always has (a section has no parent and a child shows no section).
 config_rows() {
     awk '
         /^services:[ \t]*$/ { in_services = 1; next }
@@ -216,11 +221,13 @@ config_rows() {
         | awk -F'|' '
             { sec[NR] = $1; root[NR] = $2; child[NR] = $3; svc[NR] = $4; par[NR] = $5; n = NR }
             END {
-                for (i = 1; i <= n; i++) {
-                    if (child[i] == 0) { printf "%s\t%s\n", svc[i], sec[i]; continue }
-                    last = !(i < n && child[i + 1] == 1 && root[i + 1] == root[i])
-                    printf "%s %s\talso starts %s\n", (last ? "`-" : "|-"), svc[i], par[i]
-                }
+                for (i = 1; i <= n; i++)
+                    if (child[i] == 0) {
+                        section = sec[i]
+                        gsub(/:/, " ", section)
+                        printf "%s:%s:\n", svc[i], section
+                    } else
+                        printf "|- %s::%s\n", svc[i], par[i]
             }'
 }
 
@@ -331,12 +338,14 @@ cmd_config() {
     # service name is its last whitespace-separated word. Fed by a here-doc,
     # not a pipe, so `set --` lands in this shell.
     count=0
+    edges=""
     set --
-    tab="$(printf '\t')"
-    while IFS="$tab" read -r tag desc; do
+    while IFS=: read -r tag desc parent; do
         [ -n "$tag" ] || continue
         svc="${tag##* }"
         in_lines "$known" "$svc" || continue
+        [ -z "$parent" ] || edges="$edges$svc $parent
+"
         if in_lines "$old_enabled" "$svc"; then
             set -- "$@" "$tag" "$desc" on
         else
@@ -367,7 +376,23 @@ EOF
 
     # Back from display tags to service names (drop the tree glyphs).
     selection="$(printf '%s\n' "$selection" | sed 's/^.* //' | grep -v '^$' || true)"
-    new_profiles="$(printf '%s\n' "$selection" | grep -v '^$' | paste -sd, - || true)"
+
+    # Selecting an indented service starts the one it hangs off, whether or
+    # not that box is ticked (its profile is what compose activates). Adding
+    # it here keeps .env stating what actually runs, so the box comes back
+    # ticked next time instead of silently reappearing.
+    while IFS=' ' read -r child parent; do
+        [ -n "$parent" ] || continue
+        in_lines "$selection" "$child" || continue
+        in_lines "$selection" "$parent" && continue
+        echo "ℹ️  $parent enabled too: $child needs it"
+        selection="$selection
+$parent"
+    done <<EOF
+$edges
+EOF
+    selection="$(printf '%s\n' "$selection" | grep -v '^$' | sort -u || true)"
+    new_profiles="$(printf '%s\n' "$selection" | paste -sd, - || true)"
     if [ "$(printf '%s\n' "$selection" | sort)" = "$known" ]; then
         new_profiles=all
     fi
@@ -382,11 +407,6 @@ EOF
     for svc in $known; do
         if in_lines "$new_enabled" "$svc"; then
             in_lines "$old_enabled" "$svc" || newly_on="$newly_on $svc"
-            # Unchecked but still enabled: a checked service activates its
-            # profile too, so the box cannot be cleared on its own. Said here
-            # because the row comes back checked on the next run.
-            in_lines "$selection" "$svc" \
-                || echo "⚠️  $svc stays enabled: another selected service auto-activates it"
         else
             if in_lines "$old_enabled" "$svc"; then newly_off="$newly_off $svc"; fi
         fi

--- a/scripts/services.sh
+++ b/scripts/services.sh
@@ -135,10 +135,8 @@ validate_service() {
 # --- Checklist layout ---
 
 # One display row per optional service, as "<tag>:<section>:<parent>",
-# ordered by section with each coupled pair rendered as a tree: a "|- " tag is
-# a service that pulls in the one it hangs off, and <parent> names it. Every
-# child gets the same glyph - the classic last-child variant would only claim
-# that nothing follows, which the section layout already shows. Everything is derived from
+# ordered by section, with a service that pulls in another indented under it:
+# an "  - " tag hangs off the row above and <parent> names it. Everything is derived from
 # compose.yaml, so the checklist cannot drift from the stack: a service's
 # `profiles:` list names the dependents that auto-activate it (gluetun carries
 # its netns tenants, n8n carries n8n-runners), which is what makes a pair a
@@ -146,9 +144,9 @@ validate_service() {
 # borrows its first child's section (flaresolverr sits with prowlarr), else the
 # section of the service it shares a name prefix with (immich-machine-learning
 # sits with immich-server), else "Other". Sorting goes through sort(1) because
-# mawk has no asort. The glyph stays ASCII: whiptail pads the tag column by
-# byte length, so a multi-byte glyph would shift the second column of every
-# child row out of line. Fields are colon-separated, not tab-separated: `read`
+# mawk has no asort. The indent marker stays ASCII: whiptail pads the tag
+# column by byte length, so a multi-byte glyph would shift the second column of
+# every child row out of line. Fields are colon-separated, not tab-separated: `read`
 # folds runs of IFS whitespace, which would swallow the empty field a row
 # always has (a section has no parent and a child shows no section).
 config_rows() {
@@ -227,8 +225,46 @@ config_rows() {
                         gsub(/:/, " ", section)
                         printf "%s:%s:\n", svc[i], section
                     } else
-                        printf "|- %s::%s\n", svc[i], par[i]
+                        printf "  - %s::%s\n", svc[i], par[i]
             }'
+}
+
+# Linked services move together, in both directions: unticking a parent takes
+# the services hanging off it with it, and ticking one of those ticks the
+# parent back (compose starts it anyway, through the child's own profile).
+# Rule 1 keys off what changed against the state that was on screen, so the
+# two rules cannot fight over a box the user did not touch.
+close_selection() {
+    _sel="$1"
+    _shown="$2"
+    _edges="$3"
+    while IFS=' ' read -r _child _parent; do
+        [ -n "$_parent" ] || continue
+        in_lines "$_shown" "$_parent" || continue
+        in_lines "$_sel" "$_parent" && continue
+        _sel="$(printf '%s\n' "$_sel" | grep -vx "$_child" || true)"
+    done <<EOF
+$_edges
+EOF
+    while IFS=' ' read -r _child _parent; do
+        [ -n "$_parent" ] || continue
+        in_lines "$_sel" "$_child" || continue
+        in_lines "$_sel" "$_parent" && continue
+        _sel="$_sel
+$_parent"
+    done <<EOF
+$_edges
+EOF
+    printf '%s\n' "$_sel" | grep -v '^$' | sort -u || true
+}
+
+# missing_from <list-a> <list-b>: entries of a absent from b, space-joined.
+missing_from() {
+    _out=""
+    for _item in $1; do
+        in_lines "$2" "$_item" || _out="$_out $_item"
+    done
+    printf '%s' "${_out# }"
 }
 
 # --- Subcommands ---
@@ -333,24 +369,21 @@ cmd_config() {
     known="$(known_profiles)"
     old_enabled="$(services_for_profiles "$old_profiles")"
 
-    # Checked = currently enabled (same computation as list, so auto-enabled
-    # dependencies show checked). The tag carries the tree glyphs, so the
-    # service name is its last whitespace-separated word. Fed by a here-doc,
-    # not a pipe, so `set --` lands in this shell.
-    count=0
+    # The rows never change, only their tick state, so read them once. The tag
+    # carries the indent marker, so the service name is its last
+    # whitespace-separated word. Fed by a here-doc, not a pipe, so the
+    # assignments land in this shell.
+    rows=""
     edges=""
-    set --
+    count=0
     while IFS=: read -r tag desc parent; do
         [ -n "$tag" ] || continue
         svc="${tag##* }"
         in_lines "$known" "$svc" || continue
+        rows="$rows$tag:$desc
+"
         [ -z "$parent" ] || edges="$edges$svc $parent
 "
-        if in_lines "$old_enabled" "$svc"; then
-            set -- "$@" "$tag" "$desc" on
-        else
-            set -- "$@" "$tag" "$desc" off
-        fi
         count=$((count + 1))
     done <<EOF
 $(config_rows)
@@ -364,34 +397,51 @@ EOF
     [ "$list_height" -le 14 ] || list_height=14
     height=$((list_height + 8))
 
-    # whiptail/dialog draw the UI on the terminal and print the chosen tags on
-    # stderr; the fd swap captures them. A non-zero exit means Cancel/Esc.
-    if ! selection="$("$dialog_tool" --title "pi-pcloud optional services" \
-            --separate-output \
-            --checklist "Choose which optional services run (space toggles, enter applies). An indented service also starts the one above it:" \
-            "$height" 72 "$list_height" "$@" 3>&1 1>&2 2>&3)"; then
-        echo "Cancelled — no changes."
-        return 0
-    fi
-
-    # Back from display tags to service names (drop the tree glyphs).
-    selection="$(printf '%s\n' "$selection" | sed 's/^.* //' | grep -v '^$' || true)"
-
-    # Selecting an indented service starts the one it hangs off, whether or
-    # not that box is ticked (its profile is what compose activates). Adding
-    # it here keeps .env stating what actually runs, so the box comes back
-    # ticked next time instead of silently reappearing.
-    while IFS=' ' read -r child parent; do
-        [ -n "$parent" ] || continue
-        in_lines "$selection" "$child" || continue
-        in_lines "$selection" "$parent" && continue
-        echo "ℹ️  $parent enabled too: $child needs it"
-        selection="$selection
-$parent"
-    done <<EOF
-$edges
+    # Shown ticked, then re-shown whenever the linked services move a box the
+    # user did not touch: whiptail has no way to toggle a row from a callback,
+    # so the adjusted state comes back on screen to be confirmed or edited.
+    shown="$(printf '%s\n' "$old_enabled" | grep -v '^$' | sort -u || true)"
+    note=""
+    while :; do
+        set --
+        while IFS=: read -r tag desc; do
+            [ -n "$tag" ] || continue
+            svc="${tag##* }"
+            if in_lines "$shown" "$svc"; then
+                set -- "$@" "$tag" "$desc" on
+            else
+                set -- "$@" "$tag" "$desc" off
+            fi
+        done <<EOF
+$rows
 EOF
-    selection="$(printf '%s\n' "$selection" | grep -v '^$' | sort -u || true)"
+        # whiptail/dialog draw the UI on the terminal and print the chosen tags
+        # on stderr; the fd swap captures them. Non-zero means Cancel/Esc.
+        if ! selection="$("$dialog_tool" --title "pi-pcloud optional services" \
+                --separate-output \
+                --checklist "${note}Choose which optional services run (space toggles, enter applies). An indented service runs with the one above it, and the two are ticked and unticked together:" \
+                "$height" 72 "$list_height" "$@" 3>&1 1>&2 2>&3)"; then
+            echo "Cancelled — no changes."
+            return 0
+        fi
+
+        # Back from display tags to service names (drop the indent marker).
+        selection="$(printf '%s\n' "$selection" | sed 's/^.* //' | grep -v '^$' | sort -u || true)"
+        closed="$(close_selection "$selection" "$shown" "$edges")"
+        [ "$closed" != "$selection" ] || break
+
+        added="$(missing_from "$closed" "$selection")"
+        removed="$(missing_from "$selection" "$closed")"
+        note=""
+        [ -z "$added" ] || note="${note}Also ticked (needed by a ticked service): $added
+"
+        [ -z "$removed" ] || note="${note}Also unticked (they only run with the service you unticked): $removed
+"
+        note="$note
+"
+        shown="$closed"
+    done
+    selection="$closed"
     new_profiles="$(printf '%s\n' "$selection" | paste -sd, - || true)"
     if [ "$(printf '%s\n' "$selection" | sort)" = "$known" ]; then
         new_profiles=all

--- a/scripts/services.sh
+++ b/scripts/services.sh
@@ -1,0 +1,332 @@
+#!/bin/sh
+# Manage optional pi-pcloud services through Docker Compose profiles.
+#
+# Every optional service in compose.yaml carries a profile named after itself
+# (plus the catch-all "all"); COMPOSE_PROFILES in .env selects which run. A
+# missing line means everything (pre-profiles installs); an explicitly empty
+# value means core-only, matching what docker compose does with it.
+# Enabled-ness is computed with `docker compose config --services` under the
+# current selection, which is authoritative and handles coupled profiles
+# (e.g. stremio auto-enabling gluetun) for free.
+#
+# Subcommands:
+#   list               List optional services and whether each is enabled
+#   enable <service>   Add to COMPOSE_PROFILES, start it, run its init hooks
+#   disable <service>  Remove from COMPOSE_PROFILES, stop and remove it
+#   config             Interactive whiptail/dialog checklist of all services
+#
+# enable (and config, for newly-enabled services) runs the same per-service
+# hooks the systemd unit runs around `docker compose up`:
+#   scripts/<svc>-pre-start.sh                      before starting
+#   scripts/<svc>-bootstrap.sh, <svc>-oidc-bootstrap.sh   after starting
+# Hooks are found by filename convention, never hardcoded, so future services
+# get theirs automatically. Post hooks tolerate failure, like the systemd
+# unit's `-` prefix does.
+#
+# DRY_RUN=1 prints the docker/hook commands and the would-be .env line
+# instead of executing/writing anything. ENV_FILE=<path> (honored by lib.sh)
+# points at another env file, mainly for tests; the effective selection is
+# always passed to `docker compose up` explicitly so it never depends on
+# which .env compose happens to read.
+#
+# Host-only: this script is never mounted into containers, so sourcing
+# lib.sh is fine here (see docs/../scripts/lib.sh sharing constraints).
+
+set -eu
+
+# shellcheck source=scripts/lib.sh disable=SC1091
+. "$(dirname "$0")/lib.sh"
+
+# --- Helpers ---
+
+is_dry_run() { [ "${DRY_RUN:-0}" = "1" ]; }
+
+require_env_file() {
+    if [ ! -f "$ENV_FILE" ]; then
+        echo "❌ .env missing (copy .env.dist)" >&2
+        exit 1
+    fi
+}
+
+has_profiles_line() {
+    grep -qE '^COMPOSE_PROFILES=' "$ENV_FILE"
+}
+
+# Every declared profile except the catch-all "all", one per line, sorted.
+known_profiles() {
+    compose config --profiles | grep -v '^all$' | sort
+}
+
+# Services docker compose would run under the given selection.
+services_for_profiles() {
+    (cd "$PROJECT_DIR" && COMPOSE_PROFILES="$1" docker compose config --services)
+}
+
+# in_lines <newline-list> <item>: 0 if <item> is an exact line of the list.
+in_lines() {
+    printf '%s\n' "$1" | grep -qx "$2"
+}
+
+# Rewrite (or append) the COMPOSE_PROFILES line. Dry mode prints instead.
+write_profiles() {
+    if is_dry_run; then
+        echo "DRY-RUN: would write to $ENV_FILE: COMPOSE_PROFILES=$1"
+        return 0
+    fi
+    if has_profiles_line; then
+        sed -i "s|^COMPOSE_PROFILES=.*|COMPOSE_PROFILES=$1|" "$ENV_FILE"
+    else
+        printf 'COMPOSE_PROFILES=%s\n' "$1" >> "$ENV_FILE"
+    fi
+    echo "✏️  COMPOSE_PROFILES=$1"
+}
+
+# Mutating docker compose command (stop/rm). Dry mode prints instead.
+run_compose() {
+    if is_dry_run; then
+        echo "DRY-RUN: docker compose $*"
+    else
+        compose "$@"
+    fi
+}
+
+# `docker compose up` with the selection passed explicitly, so the started
+# set never depends on which .env compose reads. Dry mode prints instead.
+run_compose_up_with() {
+    _sel="$1"
+    shift
+    if is_dry_run; then
+        echo "DRY-RUN: COMPOSE_PROFILES=$_sel docker compose $*"
+    else
+        (cd "$PROJECT_DIR" && COMPOSE_PROFILES="$_sel" docker compose "$@")
+    fi
+}
+
+# Run scripts/<name> with /bin/sh if it exists; tolerate failure like the
+# systemd unit's `-` prefix does. Dry mode prints instead.
+run_hook() {
+    _hook="$PROJECT_DIR/scripts/$1"
+    [ -f "$_hook" ] || return 0
+    if is_dry_run; then
+        echo "DRY-RUN: /bin/sh $_hook"
+        return 0
+    fi
+    log "Running hook $1..."
+    /bin/sh "$_hook" || log "warning: hook $1 failed (continuing)"
+}
+
+# Validate the service argument; on failure print usage plus the valid list.
+validate_service() {
+    _svc="$1"
+    _cmd="$2"
+    _known="$3"
+    if [ -z "$_svc" ]; then
+        echo "❌ Usage: services.sh $_cmd <service> (make $_cmd s=<service>). Valid services:" >&2
+        printf '%s\n' "$_known" | sed 's/^/  - /' >&2
+        exit 1
+    fi
+    if ! in_lines "$_known" "$_svc"; then
+        echo "❌ Unknown service '$_svc'. Valid services:" >&2
+        printf '%s\n' "$_known" | sed 's/^/  - /' >&2
+        exit 1
+    fi
+}
+
+# --- Subcommands ---
+
+cmd_list() {
+    require_env_file
+    if has_profiles_line; then
+        profiles="$(get_env_value COMPOSE_PROFILES)"
+        echo "🧩 Optional services (COMPOSE_PROFILES=${profiles:-<empty: core only>})"
+    else
+        profiles=all
+        echo "🧩 Optional services (no COMPOSE_PROFILES line in .env = all)"
+    fi
+    known="$(known_profiles)"
+    enabled="$(services_for_profiles "$profiles")"
+    for svc in $known; do
+        if in_lines "$enabled" "$svc"; then
+            printf '  ✅ %s enabled\n' "$svc"
+        else
+            printf '  ⛔ %s disabled\n' "$svc"
+        fi
+    done
+}
+
+cmd_enable() {
+    svc="${1:-}"
+    require_env_file
+    known="$(known_profiles)"
+    validate_service "$svc" enable "$known"
+    if has_profiles_line; then
+        current="$(get_env_value COMPOSE_PROFILES)"
+    else
+        echo "ℹ️  No COMPOSE_PROFILES line in .env (= everything enabled): writing the full explicit list first"
+        current="$(printf '%s\n' "$known" | paste -sd, -)"
+    fi
+    if [ "$current" = "all" ]; then
+        echo "ℹ️  COMPOSE_PROFILES=all: every service is already enabled"
+        new="all"
+    else
+        case ",$current," in
+            ",,") new="$svc" ;;
+            *",$svc,"*) new="$current"; echo "ℹ️  $svc already in COMPOSE_PROFILES" ;;
+            *) new="$current,$svc" ;;
+        esac
+        write_profiles "$new"
+    fi
+    run_hook "$svc-pre-start.sh"
+    echo "🚀 Starting $svc (and any services it depends on)..."
+    run_compose_up_with "$new" up -d "$svc"
+    run_hook "$svc-bootstrap.sh"
+    run_hook "$svc-oidc-bootstrap.sh"
+    echo "✅ $svc enabled"
+}
+
+cmd_disable() {
+    svc="${1:-}"
+    require_env_file
+    known="$(known_profiles)"
+    validate_service "$svc" disable "$known"
+    if has_profiles_line; then
+        current="$(get_env_value COMPOSE_PROFILES)"
+    else
+        current=all
+    fi
+    if [ "$current" = "all" ]; then
+        echo "ℹ️  COMPOSE_PROFILES was '$current' (= everything enabled): writing the full explicit list first"
+        current="$(printf '%s\n' "$known" | paste -sd, -)"
+    fi
+    new="$(printf '%s\n' "$current" | tr ',' '\n' | grep -vx "$svc" | paste -sd, - || true)"
+    [ -n "$new" ] || echo "⚠️  COMPOSE_PROFILES is now empty: only core services will run"
+    write_profiles "$new"
+    if services_for_profiles "$new" 2>/dev/null | grep -qx "$svc"; then
+        echo "⚠️  $svc is still auto-enabled by another enabled service's profile — it will come back on the next stack restart"
+    fi
+    echo "🛑 Stopping and removing $svc..."
+    run_compose stop "$svc"
+    run_compose rm -f "$svc"
+    echo "✅ $svc disabled"
+}
+
+cmd_config() {
+    require_env_file
+    if [ ! -t 0 ] || [ ! -t 1 ]; then
+        echo "❌ 'config' needs an interactive terminal — run 'make config' from a TTY," >&2
+        echo "   or use 'make enable s=<service>' / 'make disable s=<service>' instead." >&2
+        exit 1
+    fi
+    if command -v whiptail >/dev/null 2>&1; then
+        dialog_tool=whiptail
+    elif command -v dialog >/dev/null 2>&1; then
+        dialog_tool=dialog
+    else
+        echo "❌ 'config' needs whiptail or dialog installed (sudo apt install whiptail)." >&2
+        exit 1
+    fi
+
+    if has_profiles_line; then
+        old_profiles="$(get_env_value COMPOSE_PROFILES)"
+    else
+        old_profiles=all
+    fi
+    known="$(known_profiles)"
+    old_enabled="$(services_for_profiles "$old_profiles")"
+
+    # Build the checklist rows: <tag> <status> <on|off>. Checked = currently
+    # enabled (same computation as list, so auto-enabled deps show checked).
+    count=0
+    set --
+    for svc in $known; do
+        if in_lines "$old_enabled" "$svc"; then
+            set -- "$@" "$svc" "enabled" on
+        else
+            set -- "$@" "$svc" "disabled" off
+        fi
+        count=$((count + 1))
+    done
+    if [ "$count" -eq 0 ]; then
+        echo "❌ No optional services declared in compose.yaml" >&2
+        exit 1
+    fi
+
+    list_height=$count
+    [ "$list_height" -le 14 ] || list_height=14
+    height=$((list_height + 8))
+
+    # whiptail/dialog draw the UI on the terminal and print the chosen tags on
+    # stderr; the fd swap captures them. A non-zero exit means Cancel/Esc.
+    if ! selection="$("$dialog_tool" --title "pi-pcloud optional services" \
+            --separate-output \
+            --checklist "Choose which optional services run (space toggles, enter applies):" \
+            "$height" 64 "$list_height" "$@" 3>&1 1>&2 2>&3)"; then
+        echo "Cancelled — no changes."
+        return 0
+    fi
+
+    # Compute the new COMPOSE_PROFILES value from the selection.
+    selection="$(printf '%s\n' "$selection" | grep -v '^$' || true)"
+    new_profiles="$(printf '%s\n' "$selection" | grep -v '^$' | paste -sd, - || true)"
+    if [ "$(printf '%s\n' "$selection" | sort)" = "$known" ]; then
+        new_profiles=all
+    fi
+    [ -n "$new_profiles" ] || echo "⚠️  Nothing selected: COMPOSE_PROFILES will be empty — only core services will run"
+    write_profiles "$new_profiles"
+
+    # Diff effective service sets (not raw profiles), so auto-enabled
+    # dependencies are handled and core services cancel out.
+    new_enabled="$(services_for_profiles "$new_profiles")"
+    newly_on=""
+    newly_off=""
+    for svc in $known; do
+        if in_lines "$new_enabled" "$svc"; then
+            in_lines "$old_enabled" "$svc" || newly_on="$newly_on $svc"
+        else
+            if in_lines "$old_enabled" "$svc"; then newly_off="$newly_off $svc"; fi
+        fi
+    done
+
+    if [ -z "$newly_on" ] && [ -z "$newly_off" ]; then
+        echo "✅ No service changes (COMPOSE_PROFILES=${new_profiles:-<empty: core only>})"
+        return 0
+    fi
+
+    for svc in $newly_on; do
+        run_hook "$svc-pre-start.sh"
+    done
+
+    echo "🚀 Applying selection (docker compose up -d)..."
+    run_compose_up_with "$new_profiles" up -d
+
+    for svc in $newly_off; do
+        echo "🛑 Stopping and removing $svc..."
+        run_compose stop "$svc"
+        run_compose rm -f "$svc"
+    done
+
+    for svc in $newly_on; do
+        run_hook "$svc-bootstrap.sh"
+        run_hook "$svc-oidc-bootstrap.sh"
+    done
+
+    echo "✅ Applied. COMPOSE_PROFILES=${new_profiles:-<empty: core only>}"
+    [ -z "$newly_on" ] || echo "   enabled:$newly_on"
+    [ -z "$newly_off" ] || echo "   disabled:$newly_off"
+}
+
+# --- Main ---
+
+usage() {
+    echo "Usage: services.sh {list|enable <service>|disable <service>|config}" >&2
+}
+
+cmd="${1:-}"
+if [ "$#" -gt 0 ]; then shift; fi
+case "$cmd" in
+    list) cmd_list ;;
+    enable) cmd_enable "${1:-}" ;;
+    disable) cmd_disable "${1:-}" ;;
+    config) cmd_config ;;
+    *) usage; exit 1 ;;
+esac

--- a/scripts/uptime-kuma-bootstrap.py
+++ b/scripts/uptime-kuma-bootstrap.py
@@ -25,6 +25,14 @@ failure modes a docker check is blind to - a dropped Traefik route answers 404
 while the container is happily running, and a backup that never started reports
 nothing at all.
 
+Optional services are profile-gated (COMPOSE_PROFILES in .env). Every monitor
+is still created, but a monitor owned by a disabled service is paused rather
+than deleted - pausing keeps its heartbeat history - and resumed when the
+service is enabled again. The enabled-service list is computed on the host by
+uptime-kuma-bootstrap.sh (docker compose is the authority on profiles) and
+passed in as ENABLED_SERVICES; when it is empty or missing, nothing is paused
+or resumed, so a plumbing failure can never silence real alerting.
+
 Uses direct Socket.IO calls for Uptime Kuma 2.x compatibility.
 """
 
@@ -190,6 +198,28 @@ ROUTES = [
 # healthy. A dropped router answers 404 and a broken backend 5xx: both are down.
 ROUTE_STATUSCODES = ["200-299", "301", "302", "307", "308"]
 
+# Subdomain -> compose service owning the route, where the two names differ.
+# A subdomain absent from this map is assumed to be named after its service
+# (nextcloud, kavita, ntfy, homepage, qbittorrent all are).
+ROUTE_SERVICES = {
+    "auth": "authelia",
+    "immich": "immich-server",
+    "vault": "vaultwarden",
+}
+
+# Synthetic (non-container) monitor -> the compose service whose profile gates
+# it. dns/TLS belong to profile-less core services, so compose always lists
+# them and those two never pause in practice; "vpn public ip" follows gluetun,
+# which compose enables whenever any of its dependent profiles is on; "backup
+# freshness" follows system-tools because that is the container serving its
+# probe endpoint (backrest itself is core, but the probe dies with the tool).
+SPECIAL_MONITOR_SERVICES = {
+    "vpn public ip": "gluetun",
+    "dns resolution": "pihole",
+    "TLS certificate": "traefik",
+    "backup freshness": "system-tools",
+}
+
 
 def log(msg):
     ts = time.strftime("%H:%M:%S")
@@ -229,6 +259,74 @@ def get_container_names_from_compose(project_dir):
             if match:
                 containers.append(match.group(1))
     return containers
+
+
+def get_service_containers_from_compose(project_dir):
+    """Map compose service name -> list of its container_name values.
+
+    A stateful line parse (kept dependency-free, like
+    get_container_names_from_compose): inside the top-level `services:` block,
+    a two-space-indented `name:` line selects the current service and every
+    container_name line attaches to it. Other top-level blocks (x-* anchors,
+    volumes, networks) are skipped so their two-space keys cannot be mistaken
+    for services.
+    """
+    compose_path = os.path.join(project_dir, "compose.yaml")
+    if not os.path.isfile(compose_path):
+        log(f"ERROR: compose.yaml not found at {compose_path}")
+        return {}
+    services = {}
+    in_services = False
+    current = None
+    with open(compose_path) as f:
+        for line in f:
+            if re.match(r"^services:\s*$", line):
+                in_services = True
+                current = None
+                continue
+            if re.match(r"^[A-Za-z0-9_-]+:", line):  # another top-level block
+                in_services = False
+                current = None
+                continue
+            if not in_services:
+                continue
+            match = re.match(r"^  ([A-Za-z0-9_-]+):\s*$", line)
+            if match:
+                current = match.group(1)
+                services.setdefault(current, [])
+                continue
+            match = re.match(r"^\s+container_name:\s*(\S+)", line)
+            if match and current:
+                services[current].append(match.group(1))
+    return services
+
+
+def parse_enabled_services(raw):
+    """ENABLED_SERVICES ("a,b,c") -> set of service names, or None when unknown.
+
+    Empty means unknown, never "none enabled": the bootstrap only runs when
+    uptime-kuma itself is an enabled service, so a genuinely computed list is
+    never empty and an empty value can only be a plumbing failure.
+    """
+    services = {part.strip() for part in raw.split(",") if part.strip()}
+    return services or None
+
+
+def route_service(subdomain):
+    """Compose service that owns the `route <subdomain>` monitor."""
+    return ROUTE_SERVICES.get(subdomain, subdomain)
+
+
+def monitor_should_be_active(service, enabled_services):
+    """Whether a monitor should run, given the compose service that owns it.
+
+    `service` is None for monitors not owned by a single service (groups,
+    unmapped containers): those always run. An unknown enabled set (None)
+    also pauses nothing - see parse_enabled_services.
+    """
+    if enabled_services is None or service is None:
+        return True
+    return service in enabled_services
 
 
 def get_host_name_from_traefik():
@@ -588,6 +686,52 @@ class UptimeKumaBootstrap:
             raise Exception(r.get("msg", "Failed to edit monitor"))
         return r
 
+    def pause_monitor(self, monitor_id):
+        """Pause a monitor, keeping its heartbeat history.
+        Server signature: pauseMonitor(monitorID, callback)
+        """
+        r = self._call("pauseMonitor", monitor_id)
+        if not r.get("ok"):
+            raise Exception(r.get("msg", "Failed to pause monitor"))
+        return r
+
+    def resume_monitor(self, monitor_id):
+        """Resume a paused monitor.
+        Server signature: resumeMonitor(monitorID, callback)
+        """
+        r = self._call("resumeMonitor", monitor_id)
+        if not r.get("ok"):
+            raise Exception(r.get("msg", "Failed to resume monitor"))
+        return r
+
+    def reconcile_monitor_active(self, name, monitor_id, should_be_active):
+        """Pause or resume one monitor so it tracks its service's compose profile.
+
+        Runs right after ensure_monitor. The current state comes from the
+        monitorList snapshot taken at login; a monitor added in this run is
+        not in it, and the server starts new monitors active, so missing means
+        active. ensure_monitor edits cannot flip the state in between (the
+        server's editMonitor never assigns `active`), so the snapshot stays
+        truthful and only real transitions emit a call - an idempotent re-run
+        over a converged instance stays quiet.
+        """
+        if monitor_id is None:
+            return
+        existing = self.monitors.get(name)
+        currently_active = bool(existing.get("active", True)) if existing else True
+        if currently_active == should_be_active:
+            return
+        try:
+            if should_be_active:
+                self.resume_monitor(monitor_id)
+                log(f"Resumed monitor '{name}' (service enabled again)")
+            else:
+                self.pause_monitor(monitor_id)
+                log(f"Paused monitor '{name}' (service disabled via COMPOSE_PROFILES)")
+        except Exception as e:
+            action = "resume" if should_be_active else "pause"
+            log(f"WARNING: Failed to {action} monitor '{name}': {e}")
+
     @staticmethod
     def _comparable(value):
         """Normalise a field so server-side and desired representations compare equal."""
@@ -605,8 +749,12 @@ class UptimeKumaBootstrap:
         re-shape an instance that was already bootstrapped: reparenting the flat
         list into groups, retuning intervals, or moving a monitor to another
         alert tier all happen through here. `active` is deliberately never part
-        of `desired`, and editMonitor does not touch it either, so monitors the
-        user paused by hand stay paused.
+        of `desired`, and the server-side editMonitor never assigns it (it only
+        restarts a monitor that is already active), so this method never flips
+        a paused monitor back on. Pause state is owned by
+        reconcile_monitor_active, which runs after this and tracks
+        COMPOSE_PROFILES; monitors it does not manage (groups) keep whatever
+        the user set by hand.
         """
         existing = self.monitors.get(name)
         if existing:
@@ -982,6 +1130,22 @@ def main():
         else:
             log(f"Found {len(container_names)} containers to monitor")
 
+        # Profile-disabled services keep their monitors, paused. The enabled
+        # list is computed by the host-side wrapper (docker compose is the
+        # authority on COMPOSE_PROFILES) and handed over via ENABLED_SERVICES.
+        enabled_services = parse_enabled_services(env("ENABLED_SERVICES"))
+        if enabled_services is None:
+            log("WARNING: ENABLED_SERVICES is empty or unset; treating every "
+                "service as enabled - no monitor will be paused or resumed")
+        else:
+            log(f"Enabled services ({len(enabled_services)}): "
+                + ", ".join(sorted(enabled_services)))
+        container_services = {
+            container: service
+            for service, containers in get_service_containers_from_compose(project_dir).items()
+            for container in containers
+        }
+
         for container_name in container_names:
             if container_name == "pi-uptime-kuma":
                 continue
@@ -992,8 +1156,14 @@ def main():
                     f"falling back to '{group['name']}'")
             notification_id = tier_ids.get(group["tier"]) if group["notify"] == "children" else None
             try:
-                api.ensure_container_monitor(
+                monitor_id = api.ensure_container_monitor(
                     container_name, docker_host_id, group_ids[group["name"]], group, notification_id,
+                )
+                api.reconcile_monitor_active(
+                    monitor_display_name(container_name), monitor_id,
+                    monitor_should_be_active(
+                        container_services.get(container_name), enabled_services,
+                    ),
                 )
             except Exception as e:
                 log(f"WARNING: Failed to ensure monitor for {container_name}: {e}")
@@ -1009,16 +1179,26 @@ def main():
             for subdomain, group_name in ROUTES:
                 group = groups_by_name[group_name]
                 try:
-                    api.ensure_route_monitor(
+                    monitor_id = api.ensure_route_monitor(
                         subdomain, host_name, group_ids[group_name], group, tier_for(group),
+                    )
+                    api.reconcile_monitor_active(
+                        f"route {subdomain}", monitor_id,
+                        monitor_should_be_active(route_service(subdomain), enabled_services),
                     )
                 except Exception as e:
                     log(f"WARNING: Failed to ensure route monitor for {subdomain}: {e}")
 
             group = groups_by_name["External Chain"]
             try:
-                api.ensure_tls_monitor(
+                monitor_id = api.ensure_tls_monitor(
                     host_name, group_ids["External Chain"], group, tier_for(group),
+                )
+                api.reconcile_monitor_active(
+                    "TLS certificate", monitor_id,
+                    monitor_should_be_active(
+                        SPECIAL_MONITOR_SERVICES["TLS certificate"], enabled_services,
+                    ),
                 )
             except Exception as e:
                 log(f"WARNING: Failed to ensure TLS certificate monitor: {e}")
@@ -1029,7 +1209,13 @@ def main():
         if resolver_ip:
             group = groups_by_name["Core"]
             try:
-                api.ensure_dns_monitor(resolver_ip, group_ids["Core"], group, tier_for(group))
+                monitor_id = api.ensure_dns_monitor(resolver_ip, group_ids["Core"], group, tier_for(group))
+                api.reconcile_monitor_active(
+                    "dns resolution", monitor_id,
+                    monitor_should_be_active(
+                        SPECIAL_MONITOR_SERVICES["dns resolution"], enabled_services,
+                    ),
+                )
             except Exception as e:
                 log(f"WARNING: Failed to ensure DNS monitor: {e}")
         else:
@@ -1037,7 +1223,13 @@ def main():
 
         group = groups_by_name["Remote Access"]
         try:
-            api.ensure_vpn_monitor(group_ids["Remote Access"], group, tier_for(group))
+            monitor_id = api.ensure_vpn_monitor(group_ids["Remote Access"], group, tier_for(group))
+            api.reconcile_monitor_active(
+                "vpn public ip", monitor_id,
+                monitor_should_be_active(
+                    SPECIAL_MONITOR_SERVICES["vpn public ip"], enabled_services,
+                ),
+            )
         except Exception as e:
             log(f"WARNING: Failed to ensure VPN monitor: {e}")
 
@@ -1045,8 +1237,14 @@ def main():
         # a missed backup is worth its own message rather than a group aggregate.
         group = groups_by_name["Personal Data"]
         try:
-            api.ensure_backup_freshness_monitor(
+            monitor_id = api.ensure_backup_freshness_monitor(
                 group_ids["Personal Data"], group, tier_for(group),
+            )
+            api.reconcile_monitor_active(
+                "backup freshness", monitor_id,
+                monitor_should_be_active(
+                    SPECIAL_MONITOR_SERVICES["backup freshness"], enabled_services,
+                ),
             )
         except Exception as e:
             log(f"WARNING: Failed to ensure backup freshness monitor: {e}")

--- a/scripts/uptime-kuma-bootstrap.sh
+++ b/scripts/uptime-kuma-bootstrap.sh
@@ -13,6 +13,19 @@ PYTHON_IMAGE="python:3.12-slim"
 MAX_RETRIES=90
 RETRY_INTERVAL=2
 
+# Enabled compose services, comma-separated. `docker compose config --services`
+# applies the COMPOSE_PROFILES line from .env on its own; a .env without the
+# line is the legacy everything-enabled layout, which maps to the "all"
+# profile. Empty output (compose failure) makes the python side keep every
+# monitor active rather than pausing anything.
+enabled_services_csv() {
+    if grep -q '^COMPOSE_PROFILES=' "$ENV_FILE"; then
+        compose config --services 2>/dev/null | tr '\n' ',' | sed 's/,$//'
+    else
+        (cd "$PROJECT_DIR" && COMPOSE_PROFILES=all docker compose config --services) 2>/dev/null | tr '\n' ',' | sed 's/,$//'
+    fi
+}
+
 main() {
     log "=== Uptime Kuma Bootstrap ==="
 
@@ -34,6 +47,15 @@ main() {
     HOST_NAME="${HOST_NAME:-$(get_env_value HOST_NAME)}"
     [ -n "$HOST_NAME" ] || log "WARNING: HOST_NAME not resolved; TLS certificate monitor will be skipped"
 
+    # Computed here because the bootstrap container has no docker CLI: monitors
+    # of profile-disabled services get paused (not deleted) by the python side.
+    ENABLED_SERVICES="$(enabled_services_csv)"
+    if [ -n "$ENABLED_SERVICES" ]; then
+        log "Enabled services: $ENABLED_SERVICES"
+    else
+        log "WARNING: could not determine enabled services; no monitors will be paused or resumed"
+    fi
+
     # Run bootstrap Python script inside a temporary container on the frontend
     # network so it can reach pi-uptime-kuma:3001 and pi-ntfy by container name.
     docker run --rm \
@@ -46,6 +68,7 @@ main() {
         -e PROJECT_DIR=/project \
         -e UPTIME_KUMA_URL=http://pi-uptime-kuma:3001 \
         -e HOST_NAME="$HOST_NAME" \
+        -e ENABLED_SERVICES="$ENABLED_SERVICES" \
         "$PYTHON_IMAGE" \
         sh -c 'pip install --quiet --disable-pip-version-check "python-socketio[client]" && python /bootstrap.py'
 }


### PR DESCRIPTION
## Summary

Makes every optional service individually toggleable, at runtime and (next PR) at install time.

- **compose.yaml**: each of the 24 optional services carries a profile named after itself plus a catch-all `all`; the 13 core services (traefik, authelia, lldap, postgres, redis, pihole, unbound, headscale, tailscale, ddns-updater, ntfy, backrest, homepage) stay unprofiled and always run. Shared dependencies auto-enable (gluetun for its netns tenants, n8n for n8n-runners, beszel for beszel-agent, flaresolverr for prowlarr). `required: false` on depends_on edges onto now-optional services keeps every combination startable.
- **systemd**: new `scripts/run-if-enabled.sh` gates the per-service ExecStartPre/Post scripts; `nextcloud-cron` gets an ExecCondition (skipped, not failed). `Environment=COMPOSE_PROFILES=all` keeps pre-profiles `.env` files on the everything-on behavior.
- **Tooling**: `make services` / `make enable s=<svc>` / `make disable s=<svc>` and an interactive `make config` (whiptail checklist, checked = effectively enabled). `enable` runs the service's pre-start/bootstrap hooks so no stack restart is needed.
- **Uptime Kuma**: monitors of disabled services are paused (history kept), resumed on re-enable; reconciliation is idempotent.
- **CI**: the stack test keeps an explicit profile list — profile lists merge across compose files, so `all` would re-enable the `ci-excluded` services from compose.test.yaml.

Semantics: missing `COMPOSE_PROFILES` line = everything (legacy installs); explicitly empty = core-only (matches docker compose); otherwise the comma list selects services.

## Test plan

- `docker compose config` matrix: `all` = byte-identical service set to main (37); empty = 13 core; `stremio` pulls gluetun; `immich-server` without ML; `n8n-runners` pulls n8n; CI list byte-identical to the pre-profiles CI service set.
- 13/13 functional tests on `run-if-enabled.sh` (three-state semantics, no substring match, exec exit-code propagation); shellcheck clean; `systemd-analyze verify` clean on rendered units.
- `services.sh`: dry-run matrix over .env rewrite edge cases (missing line, `all`, last-service removal, unknown service) and hook ordering (pre-start → up → bootstrap); `make services` exercised live.
- Uptime Kuma: 37/37 offline unit tests (service→container/route/synthetic mapping, decision matrix, pause/resume transitions via stubbed socket calls); upstream `editMonitor` verified to never reset `active`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)