### PR TITLE
feat(cli): a pi-pcloud command usable from anywhere

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,11 @@ PROJECT_PATH := $(shell pwd)
 UNIT         := pi-pcloud.service
 WATCH_UNIT   := pi-pcloud-authelia-ntfy.service
 COMPOSE      := docker compose
+# The pi-pcloud command and its completions. /usr/local/bin is on PATH for both
+# users and sudo; the completion directories are Debian's own.
+BIN_LINK        := /usr/local/bin/pi-pcloud
+BASH_COMPLETION := /usr/share/bash-completion/completions/pi-pcloud
+ZSH_COMPLETION  := /usr/share/zsh/vendor-completions/_pi-pcloud
 # Empty when make already runs as root: root-only images often ship without a
 # sudo binary at all (install.sh applies the same rule to its own commands).
 SUDO         := $(if $(filter 0,$(shell id -u)),,sudo)
@@ -74,6 +79,7 @@ print-required-vars:
 test:
 	@sh tests/install-test.sh
 	@sh tests/check-env-test.sh
+	@sh tests/cli-test.sh
 
 preflight: check-env
 	@echo "🔍 Preflight...";
@@ -108,6 +114,14 @@ install: check-env
 	$(SUDO) systemctl daemon-reload
 	$(SUDO) systemctl enable $(UNIT) $(WATCH_UNIT) nextcloud-cron.timer
 	@echo "✅ Systemd units installed"
+	@echo "🔗 Installing the pi-pcloud command..."
+# A symlink, not a copy: the command follows this checkout, so a git pull
+# updates it and there is no rendered duplicate to drift.
+	$(SUDO) ln -sfn $(PROJECT_PATH)/scripts/pi-pcloud $(BIN_LINK)
+	$(SUDO) mkdir -p $(dir $(BASH_COMPLETION)) $(dir $(ZSH_COMPLETION))
+	$(SUDO) cp config/completion/pi-pcloud.bash $(BASH_COMPLETION)
+	$(SUDO) cp config/completion/_pi-pcloud $(ZSH_COMPLETION)
+	@echo "✅ pi-pcloud available on PATH (new shells get completion)"
 	@if [ "$(SKIP_START)" = "1" ]; then \
 		echo "⏭️  SKIP_START=1 set; not starting stack"; \
 	else \
@@ -151,6 +165,8 @@ uninstall:
 	-$(SUDO) $(SYSCTL) --system >/dev/null
 	@echo "🌐 Removing local DNS overrides from /etc/hosts..."
 	-$(SUDO) sed -i "/# pi-pcloud local overrides/,/# end pi-pcloud local overrides/d" /etc/hosts
+	@echo "🧹 Removing the pi-pcloud command..."
+	-$(SUDO) rm -f $(BIN_LINK) $(BASH_COMPLETION) $(ZSH_COMPLETION)
 	@echo "🧹 Removing systemd units..."
 	-$(SUDO) systemctl disable $(UNIT) $(WATCH_UNIT) nextcloud-cron.timer 2>/dev/null || true
 	-$(SUDO) rm -f /etc/systemd/system/$(UNIT)

--- a/config/completion/_pi-pcloud
+++ b/config/completion/_pi-pcloud
@@ -1,0 +1,24 @@
+#compdef pi-pcloud
+# zsh completion for pi-pcloud.
+#
+# Both lists come from the command itself (--list-commands reads the Makefile,
+# --list-services reads compose.yaml), so nothing here has to be updated when a
+# command or a service is added.
+_pi-pcloud() {
+    local -a items
+
+    if (( CURRENT == 2 )); then
+        items=( ${(f)"$(pi-pcloud --list-commands 2>/dev/null)"} )
+        _describe -t commands 'pi-pcloud command' items
+        return
+    fi
+
+    case ${words[2]} in
+        enable|disable)
+            items=( ${(f)"$(pi-pcloud --list-services 2>/dev/null)"} )
+            _describe -t services 'service' items
+            ;;
+    esac
+}
+
+_pi-pcloud "$@"

--- a/config/completion/pi-pcloud.bash
+++ b/config/completion/pi-pcloud.bash
@@ -1,0 +1,23 @@
+# bash completion for pi-pcloud.
+#
+# Both lists come from the command itself (--list-commands reads the Makefile,
+# --list-services reads compose.yaml), so nothing here has to be updated when a
+# command or a service is added.
+_pi_pcloud() {
+    local cur prev
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD - 1]}"
+
+    if [ "$COMP_CWORD" -eq 1 ]; then
+        mapfile -t COMPREPLY < <(compgen -W "$(pi-pcloud --list-commands 2>/dev/null)" -- "$cur")
+        return 0
+    fi
+
+    case "$prev" in
+        enable | disable)
+            mapfile -t COMPREPLY < <(compgen -W "$(pi-pcloud --list-services 2>/dev/null)" -- "$cur")
+            ;;
+        *) COMPREPLY=() ;;
+    esac
+}
+complete -F _pi_pcloud pi-pcloud

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -1,8 +1,23 @@
 # Commands Reference
 
-Run all commands from the pi-pcloud directory: `/opt/pi-pcloud`
+## The `pi-pcloud` command
+
+`make install` puts a `pi-pcloud` command on `PATH`, so everything below is reachable from any directory:
+
+```bash
+pi-pcloud config             # same as `make config`
+pi-pcloud enable stremio     # same as `make enable s=stremio`
+pi-pcloud status             # same as `make status`
+pi-pcloud                    # the command list
+```
+
+It is a thin dispatcher onto the Makefile — same output, same exit code, and a target added there needs no change here. Tab completion covers both the commands and, after `enable` / `disable`, the service names (bash and zsh; open a new shell after installing).
+
+The command is a symlink to `scripts/pi-pcloud` inside the checkout, so `git pull` updates it. Point `PI_PCLOUD_DIR` at another checkout to override which one it drives.
 
 ## Make Commands
+
+Run these from the pi-pcloud directory (`/opt/pi-pcloud`), or use the `pi-pcloud` command above from anywhere.
 
 | Command | Description |
 |---------|-------------|

--- a/scripts/pi-pcloud
+++ b/scripts/pi-pcloud
@@ -1,0 +1,105 @@
+#!/bin/sh
+# The stack's command line, reachable from anywhere.
+#
+#   pi-pcloud config
+#   pi-pcloud enable stremio
+#   pi-pcloud start | stop | status | logs | doctor | services | ...
+#
+# A dispatcher, not a second implementation: the Makefile stays the single
+# source of truth and every command is forwarded to it, so a target added there
+# is reachable here without touching this file. Only the commands whose
+# arguments read better positionally are translated (`enable stremio` instead
+# of `s=stremio`); everything else is passed through after being checked
+# against make itself.
+#
+# Installed by `make install` as a symlink in /usr/local/bin, so the command
+# follows the checkout it points at: a `git pull` updates it too, and there is
+# no rendered copy to drift.
+
+set -eu
+
+SELF="$0"
+usage_hint="Run 'pi-pcloud' with no argument for the command list."
+
+die() {
+    printf 'pi-pcloud: %s\n' "$*" >&2
+    exit 1
+}
+
+# The project directory, in this order:
+#   1. PI_PCLOUD_DIR, the documented override (install.sh honours it too)
+#   2. where this script really lives, following the /usr/local/bin symlink,
+#      which also covers running it straight out of a checkout
+#   3. the installed systemd unit, for a copied rather than symlinked script
+project_dir() {
+    if [ -n "${PI_PCLOUD_DIR:-}" ]; then
+        printf '%s' "$PI_PCLOUD_DIR"
+        return 0
+    fi
+
+    _real="$(readlink -f "$SELF" 2>/dev/null || true)"
+    if [ -n "$_real" ]; then
+        _candidate="$(dirname "$(dirname "$_real")")"
+        if [ -f "$_candidate/Makefile" ] && [ -f "$_candidate/compose.yaml" ]; then
+            printf '%s' "$_candidate"
+            return 0
+        fi
+    fi
+
+    _unit="$(systemctl show -p WorkingDirectory --value pi-pcloud.service 2>/dev/null || true)"
+    # systemd prefixes the value with '!' when the setting is marked as such.
+    _unit="${_unit#!}"
+    if [ -n "$_unit" ] && [ -f "$_unit/Makefile" ]; then
+        printf '%s' "$_unit"
+        return 0
+    fi
+    return 1
+}
+
+DIR="$(project_dir)" || die "could not find the pi-pcloud checkout — set PI_PCLOUD_DIR=/path/to/pi-pcloud"
+[ -f "$DIR/Makefile" ] || die "$DIR is not a pi-pcloud checkout (no Makefile)"
+
+# Every command name comes from the Makefile, so this list cannot go stale.
+list_commands() {
+    grep -oE '^[a-z][a-z0-9-]*:' "$DIR/Makefile" | tr -d ':' | sort -u
+}
+
+# Service names for `enable`/`disable`, read straight out of compose.yaml
+# (no docker call, so completion stays instant).
+list_services() {
+    sh "$DIR/scripts/services.sh" names 2>/dev/null || true
+}
+
+# --no-print-directory: the wrapper is the interface, so make's "Entering
+# directory" noise would leak an implementation detail into every command.
+run_make() {
+    exec make --no-print-directory -C "$DIR" "$@"
+}
+
+cmd="${1:-}"
+[ "$#" -eq 0 ] || shift
+
+case "$cmd" in
+    "" | help | -h | --help) run_make help ;;
+    # Hidden, for the completion scripts.
+    --list-commands) list_commands ;;
+    --list-services) list_services ;;
+    enable | disable)
+        [ "$#" -eq 1 ] || die "usage: pi-pcloud $cmd <service>"
+        run_make "$cmd" "s=$1"
+        ;;
+    headscale-register)
+        [ "$#" -eq 1 ] || die "usage: pi-pcloud headscale-register <key>"
+        run_make headscale-register "$1"
+        ;;
+    *)
+        # Checked by asking make, not by keeping a copy of its target list;
+        # only the status matters, so a translated error message cannot break
+        # the check. -n never runs a recipe.
+        if ! make --no-print-directory -C "$DIR" -n "$cmd" >/dev/null 2>&1; then
+            printf 'pi-pcloud: unknown command %s\n%s\n' "$cmd" "$usage_hint" >&2
+            exit 2
+        fi
+        run_make "$cmd" "$@"
+        ;;
+esac

--- a/scripts/services.sh
+++ b/scripts/services.sh
@@ -16,6 +16,7 @@
 #   config             Interactive picker (scripts/services-picker.py)
 #   pick               Same picker, printing the chosen COMPOSE_PROFILES value
 #                      instead of applying it (used by install.sh)
+#   names              The optional service names, one per line (completion)
 #
 # enable (and config, for newly-enabled services) runs the same per-service
 # hooks the systemd unit runs around `docker compose up`:
@@ -399,6 +400,12 @@ cmd_pick() {
     printf '%s\n' "$_value"
 }
 
+# Just the service names, one per line: read straight out of compose.yaml with
+# no docker call, so shell completion stays instant.
+cmd_names() {
+    config_rows | cut -d: -f1
+}
+
 cmd_config() {
     require_env_file
     known="$(known_profiles)"
@@ -471,7 +478,7 @@ cmd_config() {
 # --- Main ---
 
 usage() {
-    echo "Usage: services.sh {list|enable <service>|disable <service>|config|pick}" >&2
+    echo "Usage: services.sh {list|enable <service>|disable <service>|config|pick|names}" >&2
 }
 
 cmd="${1:-}"
@@ -482,5 +489,6 @@ case "$cmd" in
     disable) cmd_disable "${1:-}" ;;
     config) cmd_config ;;
     pick) cmd_pick ;;
+    names) cmd_names ;;
     *) usage; exit 1 ;;
 esac

--- a/tests/cli-test.sh
+++ b/tests/cli-test.sh
@@ -1,0 +1,109 @@
+#!/bin/sh
+# Function-level tests for scripts/pi-pcloud.
+#
+# `make` is stubbed on PATH, so every case asserts what the dispatcher would
+# have run without running it — no container, no systemd, no host change.
+# Run with `make test`.
+set -eu
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(dirname "$TESTS_DIR")"
+CLI="$REPO_DIR/scripts/pi-pcloud"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+
+ok() {
+    if [ "$2" = "$3" ]; then
+        pass=$((pass + 1))
+    else
+        fail=$((fail + 1))
+        printf 'FAIL %s\n  got  [%s]\n  want [%s]\n' "$1" "$2" "$3"
+    fi
+}
+
+# A make that reports what it was asked to do, and answers the dispatcher's
+# `make -n <target>` probe from a fixed list of known targets.
+mkdir -p "$WORK/bin"
+cat >"$WORK/bin/make" <<'STUB'
+#!/bin/sh
+for arg in "$@"; do
+    if [ "$arg" = "-n" ]; then
+        target="$(eval printf '%s' "\${$#}")"
+        case "$target" in
+            start | stop | status | logs | config | services | doctor) exit 0 ;;
+            *) exit 1 ;;
+        esac
+    fi
+done
+printf 'MAKE %s\n' "$*"
+STUB
+chmod +x "$WORK/bin/make"
+PATH="$WORK/bin:$PATH"
+export PATH
+
+cli() { PI_PCLOUD_DIR="$REPO_DIR" sh "$CLI" "$@" 2>&1 || true; }
+
+# --- dispatch ---------------------------------------------------------------
+
+ok "no argument shows help"   "$(cli)"          "MAKE --no-print-directory -C $REPO_DIR help"
+ok "help is forwarded"        "$(cli help)"     "MAKE --no-print-directory -C $REPO_DIR help"
+ok "a plain command passes"   "$(cli status)"   "MAKE --no-print-directory -C $REPO_DIR status"
+ok "logs passes through"      "$(cli logs)"     "MAKE --no-print-directory -C $REPO_DIR logs"
+
+# The argument shape this command exists for: positional, not s=<service>.
+ok "enable takes a service"   "$(cli enable stremio)" \
+    "MAKE --no-print-directory -C $REPO_DIR enable s=stremio"
+ok "disable takes a service"  "$(cli disable stremio)" \
+    "MAKE --no-print-directory -C $REPO_DIR disable s=stremio"
+
+case "$(cli enable)" in
+    *"usage: pi-pcloud enable"*) ok "enable without a service explains itself" yes yes ;;
+    *) ok "enable without a service explains itself" "$(cli enable)" yes ;;
+esac
+case "$(cli enable a b)" in
+    *"usage: pi-pcloud enable"*) ok "enable refuses two services" yes yes ;;
+    *) ok "enable refuses two services" "$(cli enable a b)" yes ;;
+esac
+
+ok "headscale-register takes a key" "$(cli headscale-register abc123)" \
+    "MAKE --no-print-directory -C $REPO_DIR headscale-register abc123"
+
+# An unknown command must not surface a raw make failure.
+out="$(cli no-such-command)"
+case "$out" in
+    *"unknown command no-such-command"*) ok "unknown command is explained" yes yes ;;
+    *) ok "unknown command is explained" "$out" yes ;;
+esac
+PI_PCLOUD_DIR="$REPO_DIR" sh "$CLI" no-such-command >/dev/null 2>&1 && rc=0 || rc=$?
+ok "unknown command exits 2" "$rc" 2
+
+# --- the lists behind completion --------------------------------------------
+
+case "$(cli --list-commands | tr '\n' ' ')" in
+    *start*stop*) ok "commands come from the Makefile" yes yes ;;
+    *) ok "commands come from the Makefile" "$(cli --list-commands | tr '\n' ' ')" yes ;;
+esac
+case "$(cli --list-services | tr '\n' ' ')" in
+    *stremio*) ok "services come from compose.yaml" yes yes ;;
+    *) ok "services come from compose.yaml" "$(cli --list-services | tr '\n' ' ')" yes ;;
+esac
+
+# --- finding the checkout ---------------------------------------------------
+
+# Installed shape: a symlink on PATH, with no PI_PCLOUD_DIR to help.
+ln -sfn "$CLI" "$WORK/bin/pi-pcloud"
+ok "resolves the checkout through the symlink" \
+    "$(env -u PI_PCLOUD_DIR sh "$WORK/bin/pi-pcloud" status 2>&1 || true)" \
+    "MAKE --no-print-directory -C $REPO_DIR status"
+
+out="$(PI_PCLOUD_DIR="$WORK/empty" sh "$CLI" status 2>&1 || true)"
+case "$out" in
+    *"not a pi-pcloud checkout"*) ok "a wrong PI_PCLOUD_DIR is refused" yes yes ;;
+    *) ok "a wrong PI_PCLOUD_DIR is refused" "$out" yes ;;
+esac
+
+printf '\n%s: %d passed, %d failed\n' "$(basename "$0")" "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Implements #231, completion included.

## What

`make install` now puts a `pi-pcloud` command on `PATH`:

```bash
pi-pcloud config             # make config
pi-pcloud enable stremio     # make enable s=stremio
pi-pcloud status | logs | doctor | services | start | stop | ...
pi-pcloud                    # the command list
```

## How it stays maintainable

- **A dispatcher, not a second implementation.** Everything is forwarded to `make -C <dir>`, so the Makefile remains the single source of truth and a target added there is reachable without touching the wrapper. Only `enable` / `disable` / `headscale-register` are translated, to take their argument positionally instead of `s=<service>`.
- **An unknown command** is detected by asking make itself (`make -n <target>`, status only — a localised error message cannot break the check), then the command list is printed rather than a raw make failure.
- **A symlink, not a rendered copy.** `/usr/local/bin/pi-pcloud` points into the checkout, so `git pull` updates the command and there is no generated duplicate to drift. `PI_PCLOUD_DIR` overrides which checkout it drives, and a copied (rather than symlinked) script still finds its way through the installed unit's `WorkingDirectory`.
- **Completion lists come from the source of truth too**: `--list-commands` reads the Makefile, `--list-services` calls a new `services.sh names` — a compose.yaml parse with no docker call, 7 ms, so tab completion stays instant.
- `--no-print-directory`, so make's "Entering directory" does not leak through what is meant to be the interface.

## Test plan

- `tests/cli-test.sh` (new, wired into `make test`): 15 cases with `make` stubbed on `PATH` — dispatch, `enable`/`disable` argument shape and their usage errors, `headscale-register`, unknown command message and exit code 2, both completion lists, resolution through the installed symlink with no `PI_PCLOUD_DIR`, and a wrong `PI_PCLOUD_DIR` refused.
- Full suite: `install-test.sh` 71, `check-env-test.sh` 14, `cli-test.sh` 15.
- Driven for real from `/tmp` against the live checkout: `pi-pcloud services` and `--list-commands` behave as expected.
- Completions exercised functionally, not just linted: bash `st` → `start status stop`, `enable str` → `stremio`, nothing after an unrelated command; zsh loads through `compinit` and registers `_pi-pcloud`. `shellcheck` clean (bash and dash), `zsh -n` clean.
- `make -n install` / `make -n uninstall` reviewed: `ln -sfn` and `rm -f` are idempotent.

## Notes

- Shell completion was listed as out of scope in #231; it is included here since the command list is already stable.
- Not covered: `make install` was not run on the live host as part of this work, so the symlink and completion files land on first install (or on the next `make install`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)