### PR TITLE
feat(make): take the service name positionally for enable/disable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,18 @@ SUDO         := $(if $(filter 0,$(shell id -u)),,sudo)
 # there, so sudo's secure_path no longer covers it either.
 SYSCTL       := $(firstword $(wildcard /usr/sbin/sysctl /sbin/sysctl) sysctl)
 
-ifeq (headscale-register,$(firstword $(MAKECMDGOALS)))
-HEADSCALE_KEY := $(word 2,$(MAKECMDGOALS))
-$(eval $(HEADSCALE_KEY):;@:)
+# A second word on the command line is an argument, not a target: `make enable
+# stremio` reads better than `make enable s=stremio`, and the pi-pcloud command
+# can then pass its own arguments straight through. The stub rule keeps make
+# from trying to build that word as a goal; s=<service> still works.
+ifneq (,$(filter enable disable headscale-register,$(firstword $(MAKECMDGOALS))))
+GOAL_ARG := $(word 2,$(MAKECMDGOALS))
+ifneq (,$(GOAL_ARG))
+$(eval $(GOAL_ARG):;@:)
 endif
+endif
+SERVICE       := $(if $(s),$(s),$(GOAL_ARG))
+HEADSCALE_KEY := $(GOAL_ARG)
 
 help:
 	@echo "Commands:"
@@ -36,8 +44,8 @@ help:
 	@echo "  status           Show systemd status"
 	@echo "  logs             Follow compose logs"
 	@echo "  services         List optional services and whether each is enabled"
-	@echo "  enable s=<name>  Enable an optional service (updates COMPOSE_PROFILES, starts it, runs its init hooks)"
-	@echo "  disable s=<name> Disable an optional service (updates COMPOSE_PROFILES, stops it)"
+	@echo "  enable <name>    Enable an optional service (updates COMPOSE_PROFILES, starts it, runs its init hooks)"
+	@echo "  disable <name>   Disable an optional service (updates COMPOSE_PROFILES, stops it)"
 	@echo "  config           Interactive checklist to choose which services run"
 	@echo "  doctor           Report anything outside its threshold (disk, RAM, temp, containers, backups)"
 	@echo "  preflight        Quick env readiness check"
@@ -216,10 +224,10 @@ services:
 	@/bin/sh scripts/services.sh list
 
 enable:
-	@/bin/sh scripts/services.sh enable "$(s)"
+	@/bin/sh scripts/services.sh enable "$(SERVICE)"
 
 disable:
-	@/bin/sh scripts/services.sh disable "$(s)"
+	@/bin/sh scripts/services.sh disable "$(SERVICE)"
 
 config:
 	@/bin/sh scripts/services.sh config

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -6,12 +6,12 @@
 
 ```bash
 pi-pcloud config             # same as `make config`
-pi-pcloud enable stremio     # same as `make enable s=stremio`
+pi-pcloud enable stremio     # same as `make enable stremio`
 pi-pcloud status             # same as `make status`
 pi-pcloud                    # the command list
 ```
 
-It is a thin dispatcher onto the Makefile — same output, same exit code, and a target added there needs no change here. Tab completion covers both the commands and, after `enable` / `disable`, the service names (bash and zsh; open a new shell after installing).
+It is a thin dispatcher onto the Makefile — same output, same exit code, same arguments (both forms take the service name positionally; `s=<service>` still works with `make` for compatibility), and a target added there needs no change here. Tab completion covers both the commands and, after `enable` / `disable`, the service names (bash and zsh; open a new shell after installing).
 
 The command is a symlink to `scripts/pi-pcloud` inside the checkout, so `git pull` updates it. Point `PI_PCLOUD_DIR` at another checkout to override which one it drives.
 
@@ -30,8 +30,8 @@ Run these from the pi-pcloud directory (`/opt/pi-pcloud`), or use the `pi-pcloud
 | `make status` | Show stack status and port bindings |
 | `make logs` | Follow live logs |
 | `make services` | List optional services and whether each is enabled (`COMPOSE_PROFILES`) |
-| `make enable s=<service>` | Enable an optional service: update `COMPOSE_PROFILES` in `.env`, start it, run its init hooks |
-| `make disable s=<service>` | Disable an optional service: update `COMPOSE_PROFILES` in `.env` and stop it |
+| `make enable <service>` | Enable an optional service: update `COMPOSE_PROFILES` in `.env`, start it, run its init hooks |
+| `make disable <service>` | Disable an optional service: update `COMPOSE_PROFILES` in `.env` and stop it |
 | `make config` | Interactive checklist to choose which optional services run |
 | `make update` | `git pull` + restart |
 | `make doctor` | Report anything outside its threshold: disk, RAM, swap, temperature, load, containers, restarts, backups |
@@ -72,8 +72,8 @@ make restart
 ```bash
 make services                           # What is enabled right now?
 make config                             # Interactive checklist (whiptail)
-make enable s=stremio                   # Auto-starts gluetun too, runs init hooks
-make disable s=n8n
+make enable stremio                     # Auto-starts gluetun too, runs init hooks
+make disable n8n
 ```
 
 **View service logs:**

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -219,8 +219,8 @@ An install whose `.env` predates this feature (no `COMPOSE_PROFILES` line) keeps
 ```bash
 make config              # Interactive checklist — the comfortable path
 make services            # List each optional service and whether it is enabled
-make enable s=stremio    # Add it to COMPOSE_PROFILES and start it (plus dependencies)
-make disable s=stremio   # Remove it from COMPOSE_PROFILES and stop it
+make enable stremio      # Add it to COMPOSE_PROFILES and start it (plus dependencies)
+make disable stremio     # Remove it from COMPOSE_PROFILES and stop it
 ```
 
 `make config` opens a terminal picker listing every optional service (ticked = currently enabled, including auto-enabled dependencies); on confirm it rewrites `COMPOSE_PROFILES` and starts/stops whatever changed. Services are listed under the section they belong to, and one that is pointless on its own is indented under the service it belongs to:

--- a/scripts/pi-pcloud
+++ b/scripts/pi-pcloud
@@ -6,11 +6,10 @@
 #   pi-pcloud start | stop | status | logs | doctor | services | ...
 #
 # A dispatcher, not a second implementation: the Makefile stays the single
-# source of truth and every command is forwarded to it, so a target added there
-# is reachable here without touching this file. Only the commands whose
-# arguments read better positionally are translated (`enable stremio` instead
-# of `s=stremio`); everything else is passed through after being checked
-# against make itself.
+# source of truth and every command is forwarded to it verbatim, so a target
+# added there is reachable here without touching this file. Arguments need no
+# translation either — the Makefile takes them positionally — which leaves
+# nothing here to drift.
 #
 # Installed by `make install` as a symlink in /usr/local/bin, so the command
 # follows the checkout it points at: a `git pull` updates it too, and there is
@@ -84,14 +83,6 @@ case "$cmd" in
     # Hidden, for the completion scripts.
     --list-commands) list_commands ;;
     --list-services) list_services ;;
-    enable | disable)
-        [ "$#" -eq 1 ] || die "usage: pi-pcloud $cmd <service>"
-        run_make "$cmd" "s=$1"
-        ;;
-    headscale-register)
-        [ "$#" -eq 1 ] || die "usage: pi-pcloud headscale-register <key>"
-        run_make headscale-register "$1"
-        ;;
     *)
         # Checked by asking make, not by keeping a copy of its target list;
         # only the status matters, so a translated error message cannot break

--- a/scripts/services.sh
+++ b/scripts/services.sh
@@ -138,7 +138,7 @@ validate_service() {
     _cmd="$2"
     _known="$3"
     if [ -z "$_svc" ]; then
-        echo "❌ Usage: services.sh $_cmd <service> (make $_cmd s=<service>). Valid services:" >&2
+        echo "❌ Usage: pi-pcloud $_cmd <service> (or make $_cmd <service>). Valid services:" >&2
         printf '%s\n' "$_known" | sed 's/^/  - /' >&2
         exit 1
     fi

--- a/tests/cli-test.sh
+++ b/tests/cli-test.sh
@@ -34,6 +34,7 @@ for arg in "$@"; do
         target="$(eval printf '%s' "\${$#}")"
         case "$target" in
             start | stop | status | logs | config | services | doctor) exit 0 ;;
+            enable | disable | headscale-register) exit 0 ;;
             *) exit 1 ;;
         esac
     fi
@@ -53,21 +54,14 @@ ok "help is forwarded"        "$(cli help)"     "MAKE --no-print-directory -C $R
 ok "a plain command passes"   "$(cli status)"   "MAKE --no-print-directory -C $REPO_DIR status"
 ok "logs passes through"      "$(cli logs)"     "MAKE --no-print-directory -C $REPO_DIR logs"
 
-# The argument shape this command exists for: positional, not s=<service>.
+# Arguments reach make untouched: the Makefile takes them positionally, so
+# there is no s=<service> translation left in the wrapper to get wrong.
 ok "enable takes a service"   "$(cli enable stremio)" \
-    "MAKE --no-print-directory -C $REPO_DIR enable s=stremio"
+    "MAKE --no-print-directory -C $REPO_DIR enable stremio"
 ok "disable takes a service"  "$(cli disable stremio)" \
-    "MAKE --no-print-directory -C $REPO_DIR disable s=stremio"
-
-case "$(cli enable)" in
-    *"usage: pi-pcloud enable"*) ok "enable without a service explains itself" yes yes ;;
-    *) ok "enable without a service explains itself" "$(cli enable)" yes ;;
-esac
-case "$(cli enable a b)" in
-    *"usage: pi-pcloud enable"*) ok "enable refuses two services" yes yes ;;
-    *) ok "enable refuses two services" "$(cli enable a b)" yes ;;
-esac
-
+    "MAKE --no-print-directory -C $REPO_DIR disable stremio"
+ok "enable without a service still forwards" "$(cli enable)" \
+    "MAKE --no-print-directory -C $REPO_DIR enable"
 ok "headscale-register takes a key" "$(cli headscale-register abc123)" \
     "MAKE --no-print-directory -C $REPO_DIR headscale-register abc123"
 


### PR DESCRIPTION
## Why

`pi-pcloud enable stremio` worked, but `make enable stremio` did not — it needed `s=stremio` — and the help `pi-pcloud` prints is the Makefile's own, so the interface advertised a syntax the command does not use. The `s=` form was also the only thing the wrapper had to translate, which is exactly the kind of divergence that rots.

## What

- The Makefile captures a second word on the command line as an argument and stubs it out as a goal, generalising the mechanism that already existed for `make headscale-register <key>`. `make enable stremio`, `make disable n8n` and `make headscale-register <key>` all read positionally; `s=<service>` still works for compatibility.
- `scripts/pi-pcloud` forwards arguments verbatim — the `enable`/`disable`/`headscale-register` special cases are gone. A missing service name now falls through to `services.sh`, which prints the usage *and* the list of valid names, rather than the wrapper's one-liner.
- Help text and docs updated to the positional form.

## Test plan

- `make test`: install-test 71, check-env-test 14, cli-test 14 (the two wrapper-usage cases are replaced by pass-through assertions).
- Live, on this host: `make enable stremio`, `make disable comet` and `make enable s=stremio` all reach `services.sh` correctly (checked with `DRY_RUN=1`, nothing written); `make enable` with no argument prints the service list; `make headscale-register abc123` reaches `--key "abc123"` (`make -n`).
- Through the installed command: `pi-pcloud disable comet` dry-runs correctly, and `pi-pcloud` now prints `enable <name>` / `disable <name>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)