### PR TITLE
feat(make): make update actually update the stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install uninstall start stop restart status logs doctor preflight check-env print-required-vars test services enable disable config headscale-register headscale-reset rotate-password rotate-password-full
+.PHONY: help install uninstall start stop restart update status logs doctor preflight check-env print-required-vars test services enable disable config headscale-register headscale-reset rotate-password rotate-password-full
 
 REQUIRED_ENV_VARS := HOST_NAME TIMEZONE EMAIL ADMIN_USER PASSWORD HOST_LAN_IP CLOUDFLARE_DNS_API_TOKEN CLOUDFLARE_ZONE_ID
 
@@ -41,6 +41,7 @@ help:
 	@echo "  start            Start stack"
 	@echo "  stop             Stop stack"
 	@echo "  restart          Restart stack"
+	@echo "  update           Pull the repository and updated images, rebuild, restart"
 	@echo "  status           Show systemd status"
 	@echo "  logs             Follow compose logs"
 	@echo "  services         List optional services and whether each is enabled"
@@ -199,10 +200,24 @@ stop:
 
 restart: stop start
 
+# Images are refreshed while the stack is still running, so the interruption is
+# one restart instead of a download. `pull` only covers the services the
+# current COMPOSE_PROFILES selects, and skips the five images built here, which
+# `build --pull` rebuilds against their updated bases. Pruning at the end
+# reclaims the layers the recreated containers just released — dangling images
+# only, so nothing a container still references is touched.
 update:
-	@echo "🔄 Update (git pull + restart)"
+	@echo "🔄 Updating pi-pcloud..."
+	@branch=$$(git rev-parse --abbrev-ref HEAD); 	if [ "$$branch" != "main" ]; then echo "  ⚠ on branch $$branch, not main"; fi
+	@echo "📥 Repository..."
 	@git pull --ff-only
+	@echo "📦 Images (the stack keeps running)..."
+	@$(COMPOSE) pull --ignore-buildable
+	@echo "🔨 Locally built images..."
+	@$(COMPOSE) build --pull
 	$(MAKE) restart
+	@echo "🧹 Reclaiming space from the replaced images..."
+	@docker image prune -f | tail -n1
 	@echo "✅ Update complete"
 
 status:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install uninstall start stop restart update status logs doctor preflight check-env print-required-vars test services enable disable config headscale-register headscale-reset rotate-password rotate-password-full
+.PHONY: help install install-system uninstall start stop restart update status logs doctor preflight check-env print-required-vars test services enable disable config headscale-register headscale-reset rotate-password rotate-password-full
 
 REQUIRED_ENV_VARS := HOST_NAME TIMEZONE EMAIL ADMIN_USER PASSWORD HOST_LAN_IP CLOUDFLARE_DNS_API_TOKEN CLOUDFLARE_ZONE_ID
 
@@ -37,6 +37,7 @@ HEADSCALE_KEY := $(GOAL_ARG)
 help:
 	@echo "Commands:"
 	@echo "  install          Install & enable systemd unit, start stack and initialize"
+	@echo "  install-system   Re-apply the host files only (sysctl, /etc/hosts, units, command)"
 	@echo "  uninstall        Stop stack, remove all data/volumes and uninstall systemd units"
 	@echo "  start            Start stack"
 	@echo "  stop             Stop stack"
@@ -98,8 +99,25 @@ preflight: check-env
 	@if docker run --rm -m 32m busybox sh -c 'cat /sys/fs/cgroup/memory.max 2>/dev/null || cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>/dev/null' | grep -qE '33554432|32'; then echo "✔ memory limits enforced"; else echo "⚠ memory limits NOT enforced"; fi
 	@echo "Done"
 
-install: check-env
-	@echo "📦 Installing..."
+install: check-env install-system
+	@if [ "$(SKIP_START)" = "1" ]; then \
+		echo "⏭️  SKIP_START=1 set; not starting stack"; \
+	else \
+		echo "🚀 Starting stack..."; \
+		$(SUDO) systemctl start $(UNIT); \
+		$(MAKE) start; \
+	fi
+	@echo "✅ Installation complete"
+
+# Everything this repository installs outside itself: sysctl, the /etc/hosts
+# records, the systemd units (rendered with this checkout's path) and the
+# pi-pcloud command. Split out of `install` so `update` can re-apply it after
+# a pull: these are copies, so a unit or a completion changed upstream would
+# otherwise sit stale on the host until the next install. Every step is
+# idempotent. The command itself is a symlink into the checkout and needs no
+# refresh, unlike the completions beside it.
+install-system:
+	@echo "📦 Installing system files..."
 	@echo "🧰 Applying host sysctl settings..."
 	$(SUDO) cp config/sysctl.d/pi-pcloud.conf /etc/sysctl.d/99-pi-pcloud.conf
 	$(SUDO) $(SYSCTL) --system >/dev/null
@@ -131,14 +149,6 @@ install: check-env
 	$(SUDO) cp config/completion/pi-pcloud.bash $(BASH_COMPLETION)
 	$(SUDO) cp config/completion/_pi-pcloud $(ZSH_COMPLETION)
 	@echo "✅ pi-pcloud available on PATH (new shells get completion)"
-	@if [ "$(SKIP_START)" = "1" ]; then \
-		echo "⏭️  SKIP_START=1 set; not starting stack"; \
-	else \
-		echo "🚀 Starting stack..."; \
-		$(SUDO) systemctl start $(UNIT); \
-		$(MAKE) start; \
-	fi
-	@echo "✅ Installation complete"
 
 uninstall:
 	@echo "🗑️  Uninstalling pi-pcloud..."
@@ -211,10 +221,12 @@ update:
 	@branch=$$(git rev-parse --abbrev-ref HEAD); 	if [ "$$branch" != "main" ]; then echo "  ⚠ on branch $$branch, not main"; fi
 	@echo "📥 Repository..."
 	@git pull --ff-only
+	$(MAKE) check-env
 	@echo "📦 Images (the stack keeps running)..."
 	@$(COMPOSE) pull --ignore-buildable
 	@echo "🔨 Locally built images..."
 	@$(COMPOSE) build --pull
+	$(MAKE) install-system
 	$(MAKE) restart
 	@echo "🧹 Reclaiming space from the replaced images..."
 	@docker image prune -f | tail -n1

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -34,7 +34,8 @@ Run these from the pi-pcloud directory (`/opt/pi-pcloud`), or use the `pi-pcloud
 | `make enable <service>` | Enable an optional service: update `COMPOSE_PROFILES` in `.env`, start it, run its init hooks |
 | `make disable <service>` | Disable an optional service: update `COMPOSE_PROFILES` in `.env` and stop it |
 | `make config` | Interactive checklist to choose which optional services run |
-| `make update` | Pull the repository and updated images, rebuild the locally built ones, restart, prune replaced layers |
+| `make update` | Pull the repository and updated images, rebuild the locally built ones, re-apply the host files, restart, prune replaced layers |
+| `make install-system` | Re-apply only what lives outside the repository: sysctl, `/etc/hosts` records, systemd units, the `pi-pcloud` command and its completions |
 | `make doctor` | Report anything outside its threshold: disk, RAM, swap, temperature, load, containers, restarts, backups |
 | `make check-env` | Validate required `.env` variables |
 | `make test` | Run the installer and `check-env` test suites (temporary copies only, no host changes) |
@@ -44,6 +45,8 @@ Run these from the pi-pcloud directory (`/opt/pi-pcloud`), or use the `pi-pcloud
 | `make rotate-password-full` | Same, plus every Postgres role and every other service using `PASSWORD` |
 
 **About `update`:** images are refreshed while the stack is still running, so the interruption is a single restart rather than a download. It only pulls what the current `COMPOSE_PROFILES` selects, rebuilds the five images built from `config/*/Dockerfile` against their updated bases, and finishes with `docker image prune -f`, which reclaims the layers the recreated containers released (dangling images only — nothing a container still references). Expect several minutes on a Pi when base images have moved.
+
+`update` also re-runs `install-system`, because a pull can change files this repository copies **outside** itself — the systemd units, the sysctl drop-in, the shell completions — and those copies would otherwise sit stale on the host until the next `make install`. It validates `.env` against the required-variable list first, so a variable added upstream is caught before the stack is restarted rather than after. The `pi-pcloud` command needs no refresh: it is a symlink into the checkout.
 
 ## Quick Workflows
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -8,6 +8,7 @@
 pi-pcloud config             # same as `make config`
 pi-pcloud enable stremio     # same as `make enable stremio`
 pi-pcloud status             # same as `make status`
+pi-pcloud update             # pull code and images, rebuild, restart
 pi-pcloud                    # the command list
 ```
 
@@ -33,7 +34,7 @@ Run these from the pi-pcloud directory (`/opt/pi-pcloud`), or use the `pi-pcloud
 | `make enable <service>` | Enable an optional service: update `COMPOSE_PROFILES` in `.env`, start it, run its init hooks |
 | `make disable <service>` | Disable an optional service: update `COMPOSE_PROFILES` in `.env` and stop it |
 | `make config` | Interactive checklist to choose which optional services run |
-| `make update` | `git pull` + restart |
+| `make update` | Pull the repository and updated images, rebuild the locally built ones, restart, prune replaced layers |
 | `make doctor` | Report anything outside its threshold: disk, RAM, swap, temperature, load, containers, restarts, backups |
 | `make check-env` | Validate required `.env` variables |
 | `make test` | Run the installer and `check-env` test suites (temporary copies only, no host changes) |
@@ -41,6 +42,8 @@ Run these from the pi-pcloud directory (`/opt/pi-pcloud`), or use the `pi-pcloud
 | `make headscale-reset` | Reset all VPN nodes (**destructive**) |
 | `make rotate-password` | Rotate `PASSWORD` after a leak (LLDAP admin + Authelia) |
 | `make rotate-password-full` | Same, plus every Postgres role and every other service using `PASSWORD` |
+
+**About `update`:** images are refreshed while the stack is still running, so the interruption is a single restart rather than a download. It only pulls what the current `COMPOSE_PROFILES` selects, rebuilds the five images built from `config/*/Dockerfile` against their updated bases, and finishes with `docker image prune -f`, which reclaims the layers the recreated containers released (dangling images only — nothing a container still references). Expect several minutes on a Pi when base images have moved.
 
 ## Quick Workflows
 
@@ -91,7 +94,7 @@ make headscale-register <key-from-the-url>
 
 **Update the stack:**
 ```bash
-make update                             # git pull + restart
+make update                             # code + images, then one restart
 docker compose pull && make restart     # only re-pull pinned images
 ```
 


### PR DESCRIPTION
Stacked on #233 (same file, so this keeps both diffs clean). Retarget to `main` once that merges.

## Why

`make update` existed, but it was `git pull --ff-only` + `make restart` — **no image was ever refreshed**. The four floating tags (`homepage:latest`, `qbittorrent:latest`, `gluetun:v3`, `uptime-kuma:2`) and the five images built from `config/*/Dockerfile` stayed on whatever was cached, so "update" only updated the code. It was also absent from `.PHONY` and from `make help`, so nothing pointed at it.

## What

`update` now:

1. reports the branch if it is not `main`, then `git pull --ff-only`
2. `docker compose pull --ignore-buildable` — **while the stack is still running**, so the interruption is one restart rather than a download
3. `docker compose build --pull` for the five locally built images, against their updated bases
4. `make restart`, which goes through systemd and therefore re-runs the per-service hooks
5. `docker image prune -f` to reclaim the layers the recreated containers just released — dangling images only, so nothing a container still references is touched

Pull and build both honour the current `COMPOSE_PROFILES`, so a disabled service is not downloaded.

`pi-pcloud update` needs no wrapper change — it is a pass-through, and it already shows up in `--list-commands` and in tab completion.

## Test plan

- `make -n update` reviewed end to end, including the `make restart` expansion.
- Both fetch phases dry-run cleanly on this host: `docker compose pull --ignore-buildable --dry-run` (pulls the enabled services, skips the buildable ones) and `docker compose build --pull --dry-run` (the five local images).
- `make help` and `pi-pcloud --list-commands` now list `update`.
- `make test`: 71 + 14 + 14.
- Not run for real: it restarts the stack, so that is the operator's call. `docs/COMMANDS.md` warns it can take several minutes when base images have moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)