### PR TITLE
fix(uptime-kuma): wait for the login mode instead of sleeping two seconds

### DIFF
--- a/scripts/uptime-kuma-bootstrap.py
+++ b/scripts/uptime-kuma-bootstrap.py
@@ -55,6 +55,9 @@ ROOT_GROUP = "pi-pcloud"
 # several hundred MB of SQLite for graphs nobody reads past a quarter.
 KEEP_DATA_PERIOD_DAYS = 90
 
+# Ceiling on the wait for the server to announce which login path applies.
+LOGIN_MODE_WAIT_SECONDS = 15
+
 # ntfy notification tiers. All four publish to the same topic (the "monitoring"
 # topic granted to the uptime-kuma ntfy user by scripts/ntfy-pre-start.sh); only
 # the priority differs, which is what drives the phone's do-not-disturb
@@ -428,14 +431,30 @@ class UptimeKumaBootstrap:
             try:
                 self.sio.connect(self.url, transports=["websocket"], wait_timeout=self.timeout)
                 self._connected.wait(timeout=self.timeout)
-                # Give the server time to emit autoLogin or setup.
-                time.sleep(2)
+                self._wait_for_login_mode()
                 return
             except Exception as e:
                 last_err = e
                 time.sleep(2)
         log(f"ERROR: Could not connect: {last_err}")
         sys.exit(1)
+
+    def _wait_for_login_mode(self):
+        """Wait for autoLogin (auth disabled) or setup (fresh instance).
+
+        Both arrive on the server's own schedule, and a container that has just
+        been recreated routinely takes longer than a flat sleep: falling through
+        early means attempting the password login, which is not the intended
+        path once auth is disabled, and that exits the bootstrap. An instance
+        with auth still enabled emits neither event, so this is a ceiling rather
+        than a wait.
+        """
+        deadline = time.time() + LOGIN_MODE_WAIT_SECONDS
+        while time.time() < deadline:
+            if self._auto_logged_in.is_set() or self._need_setup.is_set():
+                return
+            time.sleep(0.2)
+        log(f"No autoLogin or setup within {LOGIN_MODE_WAIT_SECONDS}s; assuming auth is enabled")
 
     def disconnect(self):
         try:


### PR DESCRIPTION
## Symptom

`make update` ends with the bootstrap dead and nothing reconciled:

```
[uptime-kuma-bootstrap] Login failed: authIncorrectCreds
[stack-up] warning: uptime-kuma-bootstrap.sh failed (continuing)
```

Pre-existing — the journal shows the same line under the old systemd unit, before #251 was deployed. It only became visible now that the hooks run in the foreground instead of writing to the journal.

## Cause

`connect()` slept a flat 2 seconds for the server to announce which login path applies:

```python
self._connected.wait(timeout=self.timeout)
# Give the server time to emit autoLogin or setup.
time.sleep(2)
```

`autoLogin` (auth disabled) and `setup` (fresh instance) arrive on the server's own schedule. When neither flag is set, `setup_or_login` falls through to a password login — not the intended path once auth is disabled — and its failure is a `sys.exit(1)` that takes the whole hook with it, so no monitor, notification or status page is reconciled that run.

Measured on a freshly recreated container on this Pi:

```
15:39:12 Connecting to http://pi-uptime-kuma:3001
15:39:16 Auto-logged in (auth disabled)
```

Four seconds. The sleep lost the race every time the container had just been recreated.

## Fix

Wait for either event, up to a 15s ceiling. An instance whose auth is still enabled emits neither, so this is a ceiling rather than a wait: it returns immediately in the common case, and only a fresh install pays it once — with a log line saying why.

## Verified

Against the live instance, both settled and freshly recreated:

```
$ docker compose up -d --force-recreate uptime-kuma && sh scripts/uptime-kuma-bootstrap.sh
15:39:12 Connecting to http://pi-uptime-kuma:3001
15:39:16 Auto-logged in (auth disabled)
15:39:16 Bootstrap completed successfully
```

`make test` unaffected (no shell surface changed); `python3 -m py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)