### PR TITLE
feat(stremio): make casting work, drop the SSO that denied every client

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -38,6 +38,9 @@ HOST_LAN_SUBNET=192.168.1.0/24
 HOST_LAN_GATEWAY=192.168.1.1
 # Pi-hole IP address on the LAN
 PIHOLE_IP=192.168.1.250
+# Only used by the `stremio-lan` profile: Stremio's own LAN address, needed so it
+# can discover cast renderers. Free, in the subnet, outside the DHCP range.
+STREMIO_IP=192.168.1.251
 ALLOW_IP_RANGES=127.0.0.1/32,192.168.1.0/24,100.64.0.0/10,172.30.0.0/16
 # Pi-hole upstream DNS servers, semicolon-separated. Unbound (primary) is queried
 # first; the public resolvers only kick in if Unbound stops answering.

--- a/compose.yaml
+++ b/compose.yaml
@@ -59,6 +59,32 @@ x-healthcheck-fast: &healthcheck-fast
   retries: 3
   start_period: 10s
 
+# Stremio runs in one of two mutually exclusive modes (see docs/NETWORKING.md).
+# `network_mode` and `networks` cannot coexist and a merge key cannot remove a
+# key, so each mode is its own thin service over this shared body.
+x-stremio-common: &stremio-common
+  <<: *service-defaults
+  image: stremio/server:v4.21.1
+  environment:
+    - NO_CORS=1
+    - TZ=${TIMEZONE:-Europe/Paris}
+    # The image installs jellyfin-ffmpeg but ships these empty, and its install
+    # path is not on PATH, so the server finds no binary and cannot remux at all.
+    - FFMPEG_BIN=/usr/lib/jellyfin-ffmpeg/ffmpeg
+    - FFPROBE_BIN=/usr/lib/jellyfin-ffmpeg/ffprobe
+    # Only its truthiness is read, so "0" would still disable casting: it must
+    # be empty. Left at the image's default, /casting answers 404 to every client.
+    - CASTING_DISABLED=
+  volumes:
+    - stremio_data:/root/.stremio-server
+  healthcheck:
+    <<: *healthcheck-default
+    test: ["CMD", "curl", "-f", "http://localhost:11470/"]
+    start_period: 30s
+  deploy: *cpu-request-small
+  mem_limit: 1024m
+  oom_score_adj: *oom-score-deprioritize
+
 services:
   ddns-updater:
     <<: *service-defaults
@@ -1066,15 +1092,13 @@ services:
       - "traefik.http.routers.stremio-root.priority=30"
       - "traefik.http.routers.stremio-root.tls=true"
       - "traefik.http.routers.stremio-root.service=noop@internal"
-      - "traefik.http.routers.stremio-local.rule=Host(`stremio.${HOST_NAME:-pi.lan}`) && ClientIP(`${HOST_LAN_SUBNET:-192.168.1.0/24}`)"
-      - "traefik.http.routers.stremio-local.entrypoints=websecure"
-      - "traefik.http.routers.stremio-local.middlewares=frame-deny@docker,lan@docker"
-      - "traefik.http.routers.stremio-local.priority=20"
-      - "traefik.http.routers.stremio-local.tls=true"
-      - "traefik.http.routers.stremio-local.service=stremio"
+      # No authelia, same reason as comet below: a cast receiver fetches the stream
+      # itself and cannot pass an interactive SSO login. It was also denying every client
+      # including the LAN, since stremio.<HOST_NAME> has no access_control rule and
+      # Authelia's default_policy is deny.
       - "traefik.http.routers.stremio.rule=Host(`stremio.${HOST_NAME:-pi.lan}`)"
       - "traefik.http.routers.stremio.entrypoints=websecure"
-      - "traefik.http.routers.stremio.middlewares=frame-deny@docker,lan@docker,authelia@docker"
+      - "traefik.http.routers.stremio.middlewares=frame-deny@docker,lan@docker"
       - "traefik.http.routers.stremio.priority=10"
       - "traefik.http.routers.stremio.tls=true"
       - "traefik.http.routers.stremio.service=stremio"
@@ -1137,33 +1161,71 @@ services:
     oom_score_adj: *oom-score-deprioritize
 
   stremio:
-    <<: *service-defaults
-    image: stremio/server:v4.21.1
+    <<: *stremio-common
     container_name: pi-stremio
     profiles: ["stremio", "all"]
     network_mode: "service:gluetun"
     depends_on:
       gluetun:
         condition: service_healthy
-    environment:
-      - NO_CORS=1
-      - TZ=${TIMEZONE:-Europe/Paris}
     labels:
+      # Routed by gluetun's labels: sharing its namespace leaves this container
+      # with no address of its own for Traefik's docker provider to target.
       - "traefik.enable=false"
       - "homepage.group=Video"
       - "homepage.name=Stremio"
       - "homepage.icon=stremio.png"
       - "homepage.href=https://stremio.${HOST_NAME:-pi.lan}"
       - "homepage.description=Streaming server (VPN protected)"
-    volumes:
-      - stremio_data:/root/.stremio-server
-    healthcheck:
-      <<: *healthcheck-default
-      test: ["CMD", "curl", "-f", "http://localhost:11470/"]
-      start_period: 30s
-    deploy: *cpu-request-small
-    mem_limit: 1024m
-    oom_score_adj: *oom-score-deprioritize
+
+  # Casting alternative to `stremio` above, never both (stack-up.sh refuses it).
+  # Discovery is SSDP/mDNS multicast, which reaches no renderer from a Docker
+  # bridge and which gluetun's firewall rejects outright (EPERM on 239.255.255.250),
+  # so a cast-capable server needs its own address on the physical LAN. That
+  # address is off the VPN: torrent pieces Stremio fetches itself then leave on
+  # the residential IP, which is a real trade-off when not using a debrid addon.
+  stremio-lan:
+    <<: *stremio-common
+    container_name: pi-stremio-lan
+    profiles: ["stremio-lan"]
+    networks:
+      frontend: {}
+      lan:
+        ipv4_address: ${STREMIO_IP:-192.168.1.251}
+    # A macvlan child cannot reach its own parent host, so the public records
+    # pointing these names at HOST_LAN_IP are unusable here: reach Traefik on
+    # the frontend network instead, or upstream fetches fail with EHOSTUNREACH.
+    extra_hosts:
+      - "stremio.${HOST_NAME:-pi.lan}:172.30.11.250"
+      - "comet.${HOST_NAME:-pi.lan}:172.30.11.250"
+    labels:
+      - "homepage.group=Video"
+      - "homepage.name=Stremio"
+      - "homepage.icon=stremio.png"
+      - "homepage.href=https://stremio.${HOST_NAME:-pi.lan}"
+      - "homepage.description=Streaming server (LAN, casting)"
+      - "traefik.enable=true"
+      - "traefik.docker.network=frontend"
+      # Same host rules as gluetun's routers but higher priority, so that if
+      # gluetun is up for qbittorrent its now-dead stremio routers lose.
+      - "traefik.http.routers.stremio-lan-root.rule=Host(`stremio.${HOST_NAME:-pi.lan}`) && Path(`/`)"
+      - "traefik.http.routers.stremio-lan-root.entrypoints=websecure"
+      - "traefik.http.routers.stremio-lan-root.middlewares=frame-deny@docker,lan@docker,stremio-lan-webui-redirect@docker"
+      - "traefik.http.routers.stremio-lan-root.priority=80"
+      - "traefik.http.routers.stremio-lan-root.tls=true"
+      - "traefik.http.routers.stremio-lan-root.service=noop@internal"
+      # No authelia, same reason as the gluetun-hosted router and as comet.
+      - "traefik.http.routers.stremio-lan.rule=Host(`stremio.${HOST_NAME:-pi.lan}`)"
+      - "traefik.http.routers.stremio-lan.entrypoints=websecure"
+      - "traefik.http.routers.stremio-lan.middlewares=frame-deny@docker,lan@docker"
+      - "traefik.http.routers.stremio-lan.priority=60"
+      - "traefik.http.routers.stremio-lan.tls=true"
+      - "traefik.http.routers.stremio-lan.service=stremio-lan"
+      - "traefik.http.services.stremio-lan.loadbalancer.server.port=11470"
+      # Its own copy: the gluetun-hosted middleware is gone when gluetun is not selected.
+      - "traefik.http.middlewares.stremio-lan-webui-redirect.redirectregex.regex=^https?://([^/]+)/?$"
+      - "traefik.http.middlewares.stremio-lan-webui-redirect.redirectregex.replacement=https://app.strem.io/shell-v4.4/?streamingServer=https%3A%2F%2F$${1}"
+      - "traefik.http.middlewares.stremio-lan-webui-redirect.redirectregex.permanent=false"
 
   comet:
     <<: *service-defaults

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -51,6 +51,7 @@ Defaults suit a `192.168.1.0/24` LAN. The installer auto-detects all of these.
 | `HOST_LAN_SUBNET` | `192.168.1.0/24` | Your home network CIDR |
 | `HOST_LAN_GATEWAY` | `192.168.1.1` | Your router's IP |
 | `PIHOLE_IP` | `192.168.1.250` | Pi-hole's own LAN address — in the subnet, outside the DHCP range |
+| `STREMIO_IP` | `192.168.1.251` | Only for the `stremio-lan` profile — Stremio's own LAN address, so it can discover cast renderers. Same constraints as `PIHOLE_IP` |
 | `PIHOLE_DNS_UPSTREAMS` | `172.30.53.53#5335;1.1.1.1;9.9.9.9` | Unbound first; the public resolvers are failover only |
 | `ALLOW_IP_RANGES` | `127.0.0.1/32,192.168.1.0/24,100.64.0.0/10,172.30.0.0/16` | Comma-separated CIDRs allowed to reach the services |
 
@@ -144,13 +145,16 @@ COMPOSE_PROFILES=                                             # core services on
 
 **Core services always run** (they carry no profile): `traefik`, `authelia`, `lldap`, `postgres`, `redis`, `pihole`, `unbound`, `headscale`, `tailscale`, `ntfy`, `backrest`, `ddns-updater`, `homepage`. Pi-hole and Unbound stay core because subdomain resolution depends on the Pi-hole wildcard record; Headscale and Tailscale stay core because they provide remote access to everything else.
 
-**Optional services:** `beszel`, `beszel-agent`, `uptime-kuma`, `dockhand`, `n8n`, `n8n-runners`, `headplane`, `immich-server`, `immich-machine-learning`, `nextcloud`, `gluetun`, `qbittorrent`, `stremio`, `comet`, `prowlarr`, `kapowarr`, `flaresolverr`, `kavita`, `vaultwarden`, `llama-cpp`, `piper`, `parakeet`, `system-tools`, `open-webui`.
+**Optional services:** `beszel`, `beszel-agent`, `uptime-kuma`, `dockhand`, `n8n`, `n8n-runners`, `headplane`, `immich-server`, `immich-machine-learning`, `nextcloud`, `gluetun`, `qbittorrent`, `stremio`, `stremio-lan`, `comet`, `prowlarr`, `kapowarr`, `flaresolverr`, `kavita`, `vaultwarden`, `llama-cpp`, `piper`, `parakeet`, `system-tools`, `open-webui`.
+
+`stremio` and `stremio-lan` are the same server in two networking modes and are **mutually exclusive** — they share one data volume and the same Traefik host rules, and `stack-up.sh` refuses a selection containing both. `stremio` is the default (VPN); pick `stremio-lan` only to cast to a DLNA/UPnP renderer, and read the trade-off in [Networking → Casting](NETWORKING.md#casting-to-a-dlna-renderer) first. `stremio-lan` is not part of `all`.
 
 **Some services pull in their dependencies** — the dependency carries the dependent's profile too, so enabling one starts both:
 
 | Enabling | Also starts |
 |----------|-------------|
 | `qbittorrent`, `stremio` or `kapowarr` | `gluetun` (their VPN network namespace) |
+| `stremio-lan` | nothing — it is deliberately off the VPN |
 | `n8n-runners` | `n8n` |
 | `beszel-agent` | `beszel` |
 | `prowlarr` | `flaresolverr` |

--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -46,7 +46,70 @@ HOST_LAN_SUBNET=192.168.1.0/24
 PIHOLE_IP=192.168.1.250                 # outside the DHCP range
 ```
 
-Set your router's DHCP DNS option to `PIHOLE_IP`, or configure devices by hand. One macvlan caveat: **the Docker host itself cannot reach a macvlan IP** over the parent interface, which is why Pi-hole is also published on the host's port 53.
+Set your router's DHCP DNS option to `PIHOLE_IP`, or configure devices by hand. Two macvlan
+consequences, both load-bearing:
+
+- **The Docker host itself cannot reach a macvlan IP** over the parent interface. The Pi querying
+  its own `${HOST_LAN_IP}:53` therefore times out; it uses `127.0.0.1` instead.
+- **A LAN client must target `PIHOLE_IP`, never `${HOST_LAN_IP}`.** Docker DNATs the host's
+  published `:53` to Pi-hole's *frontend* address, but the container has a direct route to the LAN
+  subnet over the macvlan, so its reply leaves that way and never returns through the host's
+  conntrack — the DNAT is never undone and the client rejects a `reply from unexpected source`.
+  The host publish exists for the tailnet, where `100.64.0.0/10` has no direct route in the
+  container, so the reply goes back out the default gateway and the reverse NAT applies correctly.
+
+### Devices that cannot be pointed at Pi-hole
+
+Cast receivers and locked-down TVs often ignore the DHCP DNS option, or expose no DNS field at all.
+Left alone they resolve `<service>.<HOST_NAME>` through public DNS, get the WAN address, hairpin
+back through the router with a SNAT'd source, and are refused by `lan@docker`.
+
+The fix is a **specific** public A record pointing at the Pi's LAN address, unproxied:
+
+```
+<service>.<HOST_NAME>   A   <HOST_LAN_IP>    # DNS only
+```
+
+A specific record beats the `*.<HOST_NAME>` wildcard, and `ddns-updater` only manages `<HOST_NAME>`
+and the wildcard, so it never overwrites it. The answer is identical to Pi-hole's, so nothing
+diverges. Nothing new is exposed: `lan@docker` still refuses any non-LAN, non-tailnet source, and a
+private address is not routable from outside anyway.
+
+**Never do this on the wildcard.** `headscale.<HOST_NAME>` must keep resolving to the WAN address —
+it is how remote nodes reach the control plane to enrol and reconnect from outside the tailnet.
+
+Verify the router does not strip private answers (some resolvers apply DNS rebinding protection):
+`dig @<router> <service>.<HOST_NAME> +short` must return `<HOST_LAN_IP>`.
+
+## Casting to a DLNA renderer
+
+Stremio can drive a UPnP/DLNA renderer itself, but only from the physical LAN: it finds
+receivers by SSDP/mDNS **multicast**, which does not leave a Docker bridge, and which
+gluetun's firewall rejects outright (`EPERM` on `239.255.255.250`). The default `stremio`
+profile therefore never lists a device. The `stremio-lan` profile trades the VPN for a
+macvlan address (`STREMIO_IP`) and discovers renderers normally.
+
+Three things that mode needs, none of them obvious:
+
+- **`FFMPEG_BIN` / `FFPROBE_BIN`.** The upstream image installs jellyfin-ffmpeg under
+  `/usr/lib/jellyfin-ffmpeg/`, which is not on `PATH`, and ships both variables empty. Without
+  them the server finds no binary and cannot remux anything — for casting or otherwise. Set in
+  both profiles, since it is a plain defect.
+- **`CASTING_DISABLED=`.** The image sets it to `1`, and `/casting` answers 404 to every client.
+  Only its truthiness is read, so `0` would still disable it: it must be empty.
+- **`extra_hosts` pointing `stremio.<HOST_NAME>` and `comet.<HOST_NAME>` at Traefik's frontend
+  address.** A macvlan child cannot reach its parent host, so any public record aimed at
+  `HOST_LAN_IP` is unusable from inside — upstream fetches fail with `EHOSTUNREACH`.
+
+**The trade-off:** that address is off the VPN. With a debrid addon the server barely fetches
+anything itself, but with plain torrent sources the pieces it pulls leave on the residential IP.
+
+**A known limit.** `/casting/transcode.mp4` is a live ffmpeg pipe: chunked, no `Content-Length`,
+`Accept-Ranges: none`. Renderers that require a seekable resource of known length refuse it and
+stop with `ERROR_OCCURRED`, whatever the container or MIME type — a SoftAtHome (Orange decoder)
+renderer was measured doing exactly that while playing the same content served as a static file.
+Casting here works with renderers that accept a non-seekable stream; for the others the answer is
+a media server that serves files, not this.
 
 ## DNS inside containers
 
@@ -70,7 +133,7 @@ Since Pi-hole resolves `*.<HOST_NAME>` to the Pi, every service works from the V
 | `nextcloud`, `immich`, `ai`, `vault`, `ntfy` | internal | each app + its own backends | Per-app isolation; `vault` deliberately has no path to LLDAP |
 | `dns_internal` | `172.30.53.0/24`, no gateway | Pi-hole, Unbound | Nothing else can query Unbound |
 | `dns_egress` | bridge | Unbound, immich-machine-learning | Outbound-only internet access |
-| `lan` | macvlan on `HOST_LAN_PARENT` | Pi-hole | Direct LAN presence for DNS |
+| `lan` | macvlan on `HOST_LAN_PARENT` | Pi-hole, Stremio (`stremio-lan` profile only) | Direct LAN presence — DNS, and SSDP/mDNS cast discovery |
 | `n8n_runners` | bridge | n8n, n8n-runners | Task-runner traffic |
 
 ## Ports
@@ -89,12 +152,16 @@ Everything else — Postgres `5432`, Redis `6379`, LDAP `3890`, every app port �
 
 ## Cloudflare records
 
-ddns-updater maintains exactly two records against your zone, pointed at your current public IP. Nothing else needs creating by hand.
+ddns-updater maintains exactly two records against your zone, pointed at your current public IP.
 
 ```
 <HOST_NAME>      A   <your-public-ip>
 *.<HOST_NAME>    A   <your-public-ip>
 ```
+
+Nothing else is created automatically. The one case for adding a record by hand is a device that
+cannot be pointed at Pi-hole — see [above](#devices-that-cannot-be-pointed-at-pi-hole). Because
+ddns-updater only ever touches those two names, a specific record for a subdomain is safe from it.
 
 ---
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -97,7 +97,7 @@ Two consequences specific to this stack: **group membership travels in the `grou
 | Pi-hole | ✓ | ✓ | — | LAN-only + admin + 2FA |
 | Backrest | ✓ | ✓ | — | LAN-only + admin + 2FA |
 | LLDAP | ✓ | ✓ | — | LAN-only + 2FA + its own auth + `rate-limit-auth` |
-| Stremio | ✓ | ✓ | — | LAN-only + SSO; a higher-priority router bypasses SSO for LAN source IPs, since streaming clients can't do the portal |
+| Stremio | ✓ | — | — | LAN-only; streaming clients and cast receivers can't do the portal |
 | Comet | ✓ | — | — | LAN-only; Stremio fetches manifests programmatically |
 
 Services with their own account system (Immich, Kavita) deliberately do **not** stack forward-auth on top of OIDC — their apps and clients cannot complete an interactive portal.

--- a/scripts/services.sh
+++ b/scripts/services.sh
@@ -70,8 +70,25 @@ in_lines() {
     printf '%s\n' "$1" | grep -qx "$2"
 }
 
+# 0 if the comma-separated selection lists <name> exactly.
+selection_has() {
+    case ",$(printf '%s' "$1" | tr -d ' ')," in
+        *",$2,"*) return 0 ;;
+    esac
+    return 1
+}
+
 # Rewrite (or append) the COMPOSE_PROFILES line. Dry mode prints instead.
 write_profiles() {
+    # stremio and stremio-lan are one server in two networking modes, sharing a
+    # data volume and the same Traefik host rules. Refused here rather than in
+    # stack-up.sh alone, so a bad pick never reaches .env and leaves the stack
+    # unable to start (see docs/CONFIGURATION.md).
+    if selection_has "$1" stremio && selection_has "$1" stremio-lan; then
+        echo "❌ stremio and stremio-lan cannot both run: same server, two networking" >&2
+        echo "   modes, one data volume. Keep stremio (VPN) or stremio-lan (casting)." >&2
+        return 1
+    fi
     if is_dry_run; then
         echo "DRY-RUN: would write to $ENV_FILE: COMPOSE_PROFILES=$1"
         return 0
@@ -298,7 +315,14 @@ EOF
 
     # Everything ticked is written as "all", so a service added by a later
     # update is enabled too instead of silently missing from an explicit list.
-    if [ "$(printf '%s\n' "$_selection" | grep -v '^$' | sort)" = "$_known" ]; then
+    # Compared against the profiles "all" actually covers, not every declared
+    # one: a profile deliberately outside it (stremio-lan) must stay explicit,
+    # otherwise ticking it would collapse to "all" and silently not run it.
+    _allsvc="$(mktemp)"
+    services_for_profiles all | sort >"$_allsvc"
+    _known_in_all="$(printf '%s\n' "$_known" | grep -Fxf "$_allsvc" || true)"
+    rm -f "$_allsvc"
+    if [ "$(printf '%s\n' "$_selection" | grep -v '^$' | sort)" = "$_known_in_all" ]; then
         echo all
     else
         printf '%s\n' "$_selection" | grep -v '^$' | paste -sd, - || true

--- a/scripts/stack-up.sh
+++ b/scripts/stack-up.sh
@@ -34,6 +34,20 @@ if [ -z "${COMPOSE_PROFILES+x}" ]; then
     export COMPOSE_PROFILES
 fi
 
+# `stremio` and `stremio-lan` are one server in two networking modes, sharing a
+# single data volume and the same Traefik host rules. Compose cannot express
+# mutual exclusion, so refuse the combination before anything starts.
+profiles_have() {
+    case ",$(printf '%s' "${COMPOSE_PROFILES:-}" | tr -d ' \r')," in
+        *",$1,"*) return 0 ;;
+    esac
+    return 1
+}
+
+if profiles_have stremio && profiles_have stremio-lan; then
+    die "COMPOSE_PROFILES lists both stremio and stremio-lan: same server, two networking modes, one data volume - keep only one"
+fi
+
 # --- The sequence ---
 #
 # An entry is "script.sh", or "service:script.sh" to gate it on that optional

--- a/scripts/uptime-kuma-bootstrap.py
+++ b/scripts/uptime-kuma-bootstrap.py
@@ -133,6 +133,7 @@ GROUPS = [
         "containers": [
             "pi-qbittorrent",
             "pi-stremio",
+            "pi-stremio-lan",
             "pi-comet",
             "pi-prowlarr",
             "pi-kapowarr",

--- a/tests/stack-up-test.sh
+++ b/tests/stack-up-test.sh
@@ -143,6 +143,29 @@ lacks    "and still gates the others"         "$out" "HOOK prowlarr-pre-start.sh
 # Defined but empty is core-only — what docker compose itself does with it.
 out="$(run "")"
 contains "core hooks still run when empty"    "$out" "HOOK ntfy-pre-start.sh"
+
+# --- stremio / stremio-lan are exclusive ------------------------------------
+#
+# One server in two networking modes, sharing a data volume and the same Traefik
+# host rules. Refused before anything starts rather than left to fight at runtime.
+
+run_rc stremio,stremio-lan
+ok       "both stremio modes are refused"     "$rc" 1
+contains "and the reason is named"            "$out" "stremio-lan"
+
+run_rc stremio
+ok       "stremio alone is fine"              "$rc" 0
+
+run_rc stremio-lan
+ok       "stremio-lan alone is fine"          "$rc" 0
+
+# "all" does not carry stremio-lan, so the catch-all must not trip the guard.
+run_rc all
+ok       "all is not treated as both"         "$rc" 0
+
+# Exact entries only: the substring must not make stremio-lan match stremio.
+run_rc stremio-lan,comet
+ok       "no substring match on the guard"    "$rc" 0
 lacks    "empty selects no optional service"  "$out" "HOOK kavita-oidc-bootstrap.sh"
 
 # --- ordering and the compose call ------------------------------------------


### PR DESCRIPTION
## Why

Casting Stremio to a LAN TV failed, and the investigation turned up four independent faults. Everything below was measured on the running Pi 5, not inferred.

### The 403 nobody could get past

The `stremio` router stacked `authelia@docker`, but `stremio.__HOST_NAME__` has **no** `access_control` rule in `config/authelia/configuration.yml.template`, where `default_policy: deny`. Forward-auth therefore returned a hard 403 to *every* client — not even a login page. A second router, `stremio-local` (`ClientIP` on the LAN subnet, no authelia), had been masking this for LAN browsers only.

Dropping the forward-auth makes `stremio-local` redundant, since `lan@docker` already covers that subnet. Same regime as `comet`: a cast receiver fetches the stream itself and cannot pass an interactive portal.

**Security delta:** tailnet clients now reach Stremio without SSO (they got 403 before). Nothing new is exposed to the internet — `lan@docker` judges the real TCP peer with no `ipStrategy`, and a request arriving with the WAN address was verified still getting 403 after the change.

### Casting was dead three times over

| Fault | Evidence |
|---|---|
| `FFMPEG_BIN`/`FFPROBE_BIN` empty, jellyfin-ffmpeg not on `PATH` | server found no binary and could **not remux at all** — a plain defect, so both modes get the fix |
| `CASTING_DISABLED=1` set by the image | `/casting` → 404 for every client; only truthiness is read, so `"0"` would still disable it |
| SSDP/mDNS discovery blocked | multicast does not leave a Docker bridge, and gluetun rejects it outright — 42× `EPERM` on `239.255.255.250` |

The third needs a real LAN address, hence the new `stremio-lan` profile. Verified from a macvlan address: `availableInterfaces: ["192.168.1.251"]`, two renderers discovered, **0** multicast errors.

It also needs `extra_hosts` aiming `stremio.` and `comet.` at Traefik's frontend address: a macvlan child cannot reach its parent host, so a public record pointing at `HOST_LAN_IP` is unusable from inside. Without it the upstream fetch dies with `EHOSTUNREACH`; with it, the same request returns `206`.

## Mutual exclusion

`stremio` and `stremio-lan` are one server in two networking modes, sharing a data volume and the same Traefik host rules. Compose cannot express exclusion, so it is enforced twice:

- `services.sh` refuses the combination **before** writing `.env`, so a bad pick never leaves the stack unable to start.
- `stack-up.sh` refuses it again before anything starts, covering a hand-edited `.env`.

`stremio-lan` is deliberately **not** in `all`. That exposed a latent bug in the picker: its "everything ticked means `all`" shortcut compared against every declared profile, so a profile outside `all` would collapse to `all` and silently not run. It now compares against the profiles `all` actually covers — generic, no service name hardcoded.

## Known limit (documented, not fixed)

`/casting/transcode.mp4` is a live ffmpeg pipe: chunked, no `Content-Length`, `Accept-Ranges: none`. Renderers that require a seekable resource of known length refuse it and stop with `ERROR_OCCURRED`, **whatever the container or MIME type**.

Isolated by measurement on a SoftAtHome (Orange decoder) renderer: it rejects Stremio's stream, yet plays the *same content* served as a static file with `Content-Length` and ranges — in both MP4 **and** Matroska. So the container is not the variable and neither is the Pi's CPU: for an MP4 source the command is `-c copy`, a pure remux. Casting here works with renderers that accept a non-seekable stream; for the others the answer is a media server that serves files.

Two dead ends ruled out along the way, both recorded in the docs so nobody re-walks them: the MIME label (`video/x-mkv` is non-standard, but rewriting it to `video/x-matroska` did not help), and hardware acceleration (the Pi 5 has **no video encoder** — only `/dev/video19 rpi-hevc-dec`; `h264_v4l2m2m` fails with "Could not find a valid device", and Stremio's own probe reports "no viable acceleration profiles detected").

## Trade-off to accept knowingly

`stremio-lan` is off the VPN. With a debrid addon the server barely fetches anything itself; with plain torrent sources, the pieces it pulls leave on the residential IP. Called out in `compose.yaml` and `docs/NETWORKING.md`.

`STREMIO_IP` is a new `.env.dist` key, which AGENTS.md asks to avoid. A fixed macvlan address cannot come from anywhere else; `PIHOLE_IP` is the existing precedent.

## Tests

`make test`: 71 + 14 + 14 + 57 passed, 0 failed. Six new cases in `tests/stack-up-test.sh` cover the exclusion, including that `all` does not trip it and that `stremio-lan` does not substring-match `stremio`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
